### PR TITLE
feat: Add gunicorn for prod

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -14,4 +14,6 @@ WORKDIR /home/govscape
 COPY . .
 RUN poetry install
 
-CMD ["poetry", "run", "python", "scripts/start_api_server.py"]
+EXPOSE 8080
+
+CMD ["poetry", "run", "gunicorn", "-c", "gunicorn.conf.py", "scripts.python_helpers.start_api_server:create_app()"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,31 @@ To run the initial version, you first build the embeddings, indices, etc. with:
 poetry run python3 scripts/run_embedding_pipeline.py -p "data/test_data/TechnicalReport234PDFs" -d "data/test_data"
 ```
 
-Then, you run the RESTful API server with:
+Then, you run the RESTful API server with Gunicorn (for production, default worker_class=sync):
+```bash
+GUNICORN_WORKERS=2 \
+poetry run gunicorn -c gunicorn.conf.py scripts.python_helpers.start_api_server:create_app()
+```
+
+Or use the wrapper to pass your usual CLI app arguments along with Gunicorn:
+```bash
+poetry run python scripts/python_helpers/run_gunicorn.py \
+  -p data/test_data/TechnicalReport234PDFs \
+  -d data/test_data \
+  -tm ST -vm CLIP -k 20 -i Memory -- \
+  gunicorn -c gunicorn.conf.py scripts.python_helpers.start_api_server:create_app()
+```
+
+Tuning knobs (Gunicorn env vars supported by `gunicorn.conf.py`):
+- `GUNICORN_WORKERS`
+- `GUNICORN_THREADS` (only applies to gthread workers)
+- `GUNICORN_WORKER_CLASS`
+- `GUNICORN_TIMEOUT`
+- `GUNICORN_MAX_REQUESTS`
+- `GUNICORN_MAX_REQUESTS_JITTER`
+- `GUNICORN_PRELOAD_APP`
+
+For development, you can still use the simple runner:
 ```bash
 poetry run python3 scripts/start_api_server.py -p "data/test_data/TechnicalReport234PDFs" -d "data/test_data"
 ```

--- a/govscape/pyproject.toml
+++ b/govscape/pyproject.toml
@@ -27,6 +27,7 @@ reportlab = "^4.4.1"
 pytest = "^8.4.0"
 pypdfium2 = "^4.30"
 whoosh = "^2.7.4"
+gunicorn = "^23.0.0"
 
 
 [build-system]

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,24 @@
+import multiprocessing
+import os
+
+def _get_env(key: str, default: str) -> str:
+    value = os.getenv(key)
+    return value if value not in (None, "") else default
+
+bind = _get_env("GUNICORN_BIND", "0.0.0.0:8080")
+workers = int(_get_env("GUNICORN_WORKERS", str(max(2, multiprocessing.cpu_count() * 2 + 1))))
+threads = int(_get_env("GUNICORN_THREADS", "4"))
+timeout = int(_get_env("GUNICORN_TIMEOUT", "120"))
+graceful_timeout = int(_get_env("GUNICORN_GRACEFUL_TIMEOUT", "120"))
+keepalive = int(_get_env("GUNICORN_KEEPALIVE", "5"))
+worker_class = _get_env("GUNICORN_WORKER_CLASS", "sync")
+accesslog = _get_env("GUNICORN_ACCESSLOG", "-")
+errorlog = _get_env("GUNICORN_ERRORLOG", "-")
+loglevel = _get_env("GUNICORN_LOGLEVEL", "info")
+
+# Optional hardening and stability knobs
+max_requests = int(_get_env("GUNICORN_MAX_REQUESTS", "1000"))
+max_requests_jitter = int(_get_env("GUNICORN_MAX_REQUESTS_JITTER", "100"))
+
+# Preload app: False by default because models are heavy; set True if we want faster worker boot
+preload_app = _get_env("GUNICORN_PRELOAD_APP", "false").lower() in ("1", "true", "yes")

--- a/scripts/python_helpers/__init__.py
+++ b/scripts/python_helpers/__init__.py
@@ -1,0 +1,2 @@
+# Make 'scripts.python_helpers' an explicit Python package for reliable dotted imports
+

--- a/scripts/python_helpers/run_gunicorn.py
+++ b/scripts/python_helpers/run_gunicorn.py
@@ -1,0 +1,29 @@
+import os
+import shlex
+import subprocess
+import sys
+from scripts.python_helpers.start_api_server import _get_arg_parser
+
+def main():
+    if '--' in sys.argv:
+        sep_index = sys.argv.index('--')
+        app_argv = sys.argv[1:sep_index]
+        gunicorn_argv = sys.argv[sep_index + 1 :]
+    else:
+        app_argv = sys.argv[1:]
+        gunicorn_argv = [
+            'gunicorn', '-c', 'gunicorn.conf.py',
+            'scripts.python_helpers.start_api_server:create_app()'
+        ]
+
+    parser = _get_arg_parser()
+    parser.parse_args(app_argv)
+
+    # Set APP_ARGS so create_app() can parse them without interfering with gunicorn argv
+    os.environ['APP_ARGS'] = ' '.join(shlex.quote(a) for a in app_argv)
+
+    print('Running:', ' '.join(gunicorn_argv))
+    sys.exit(subprocess.call(gunicorn_argv))
+
+if __name__ == '__main__':
+    main()

--- a/scripts/python_helpers/start_api_server.py
+++ b/scripts/python_helpers/start_api_server.py
@@ -1,7 +1,9 @@
+import os
+import shlex
 import govscape as gs
 import argparse
 
-def main():
+def _get_arg_parser():
     parser = argparse.ArgumentParser(description='Start the GovScape API server')
     parser.add_argument('-p', '--pdf-directory', default='data/test_data/TechnicalReport234PDFs', help='Directory containing PDF files')
     parser.add_argument('-d', '--data-directory', default='data/test_data', help='Directory containing data files')
@@ -13,9 +15,9 @@ def main():
     parser.add_argument('--host', default='0.0.0.0', help='Host to run the server on')
     parser.add_argument('--port', type=int, default=8080, help='Port to run the server on')
     parser.add_argument('--debug', action='store_true', help='Run the server in debug mode')
-    
-    args = parser.parse_args()
-    
+    return parser
+
+def _build_app_from_args(args):
     pdf_directory = args.pdf_directory
     if args.text_model == 'ST':
         text_model = gs.ST_TextEmbeddingModel()
@@ -30,18 +32,29 @@ def main():
         raise ValueError(f"Unsupported visual model: {args.visual_model}")
 
     index_config = gs.IndexConfig(pdf_directory, args.data_directory, args.index_type)
-    
-    if args.index_type == 'Disk':
-        i.load_index()
-    
+
     server_config = gs.ServerConfig(
         index_config, 
         text_model,
         visual_model,
         k=args.top_k
     )
-    
     server = gs.Server(server_config)
+    return server
+
+def create_app():
+    parser = _get_arg_parser()
+    app_args = os.getenv('APP_ARGS', '')
+    if app_args:
+        args = parser.parse_args(shlex.split(app_args))
+    else:
+        args = parser.parse_args([])
+    return _build_app_from_args(args).app
+
+def main():
+    parser = _get_arg_parser()
+    args = parser.parse_args()
+    server = _build_app_from_args(args)
     server.run(host=args.host, port=args.port, debug=args.debug)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request migrates the API server to use Gunicorn for production deployments, adds a configurable Gunicorn setup, and introduces a wrapper script for flexible server startup. It also updates documentation to reflect these changes and ensures package structure compatibility for Gunicorn's import style.

**Production server deployment improvements:**

* Added Gunicorn as a dependency in `pyproject.toml` and created a `gunicorn.conf.py` file with environment variable-based configuration for workers, threads, timeouts, logging, and other production tuning knobs. [[1]](diffhunk://#diff-bc9101d3fd84b547b2fa53cf2ac6c297180d9db18b6accf4454342602d439401R30) [[2]](diffhunk://#diff-c98537897a2a10aa38f9e7f1a4326b13c191324698b34c40824169decf821e76R1-R24)
* Updated the Dockerfile to expose port 8080 and launch the API server using Gunicorn with the new configuration, replacing the previous direct script execution.

**Flexible server startup and CLI integration:**

* Refactored `scripts/python_helpers/start_api_server.py` to support both Gunicorn and CLI usage, including a new `create_app()` entrypoint for Gunicorn and helper functions for argument parsing and app instantiation. [[1]](diffhunk://#diff-cd1e4432dcf04ea874279024d904024635364ac2fcca2dffcc9be9fa16a35372R1-R6) [[2]](diffhunk://#diff-cd1e4432dcf04ea874279024d904024635364ac2fcca2dffcc9be9fa16a35372R18-R20) [[3]](diffhunk://#diff-cd1e4432dcf04ea874279024d904024635364ac2fcca2dffcc9be9fa16a35372L34-R57)
* Added `scripts/python_helpers/run_gunicorn.py`, a wrapper script to allow passing CLI arguments to the app while running under Gunicorn.
* Declared `scripts/python_helpers` as a Python package to ensure reliable dotted imports with Gunicorn.

**Documentation updates:**

* Expanded the `README.md` with instructions for running the API server using Gunicorn, including environment variable tuning, and clarified usage for both production and development.