### PR TITLE
Added script with multiple approaches to get pdf title name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ s5cmd = "^0.3.3"
 scipy = "^1.13"
 npm = "^0.1.1"
 awscli = "^1.42.66"
+pdfrw = "^0.4"
 
 
 [build-system]

--- a/scripts/python_helpers/get_pdf_title.py
+++ b/scripts/python_helpers/get_pdf_title.py
@@ -1,0 +1,38 @@
+from PyPDF2 import PdfReader
+import io
+def metadata(bytes):
+    reader = PdfReader(io.BytesIO(bytes))
+    info = reader.metadata
+    title = info.title
+    return title or None
+def get_pdf_title(bytes):
+    try:
+        #try getting title from metadata first
+        title = metadata(bytes)
+        if title:
+            return title
+        #if no title in metadata, try getting from first 2 pages
+        pdf = PdfReader(io.BytesIO(bytes))
+        lines = []
+        for i in pdf.pages[:2]: # get all lines
+            text = i.extract_text()
+            if text:
+                lines.extend(text.split("\n"))
+        for i in lines:
+            num_percentage = sum(p.isnumeric(p) for p in i/len(i)) #check how much of the line is numbers (to see if likely date)
+            if num_percentage > 0.3:
+                continue 
+            return "_".join(i.strip().split(" "))
+        if lines and len(lines[0].strip()) > 0: # return first line
+            return "_".join(lines[0].strip().split(" "))
+        for i in pdf.pages: # last resort, get first non empty line from all pages
+            text = i.extract_text()
+            if text:
+                for line in text.split("\n"):
+                    if line.strip():
+                        return "_".join(line.strip().split(" "))
+    except:
+        pass
+    return None
+    
+    

--- a/scripts/python_helpers/retrieve_pdfs.py
+++ b/scripts/python_helpers/retrieve_pdfs.py
@@ -9,7 +9,7 @@ import multiprocessing
 import boto3
 import time
 import io 
-
+from get_pdf_title import get_pdf_title
 def main():
     parser = argparse.ArgumentParser(description='Retrieve PDFs from S3 & store them.')
     parser.add_argument('--bucket', required=True, help='S3 bucket name')
@@ -75,9 +75,12 @@ def retrieve_and_store_pdfs(file_batch, idx, output_bucket_name, output_director
                     if not is_valid_pdf:
                         invalid_pdfs += 1
                         continue
+                    pdf_title = get_pdf_title(record.content_stream().read())
+                    if not pdf_title:
+                        pdf_title = "untitled" # if anything goes wrong
                     s3.put_object(
                         Bucket=output_bucket_name,
-                        Key=os.path.join(output_directory, output_digest + '.pdf'),
+                        Key=os.path.join(output_directory, f'{pdf_title}_{output_digest}' + '.pdf'),
                         Body=record.content_stream().read()
                     )
                     valid_pdfs += 1


### PR DESCRIPTION
Added `get_pdf_title.py` to try to get the pdf title from the following order:
1. `title` metadata
2. first line in the first 2 pages if less than 30% of its content being numbers (prevent dates)
3. First readable line in the first 2 pages
4. First readable line in the entire doc
5. Unititled_SHA1HASH
From issue #32 
@kylebd99