### PR TITLE
Dockerized Embedding

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -6,6 +6,7 @@ services:
     volumes:
       - ..:/workspace:cached
     command: sleep infinity
+    ipc: "host"
     networks:
       - devnet
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,16 @@
 .git
 .mypy_cache
+.ruff_cache
+.pytest_cache
 __pycache__
 *.pyc
 *.pyo
 *.pyd
 .DS_Store
+.containervenv/
 .venv/
 node_modules/
 interface/
 data/
+docker/
 poetry.lock

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,9 +13,6 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
-    ports:
-      # Externally available at 8081, internally available at govscape:8080
-      - "8081:8080"
     volumes:
       - ${LOCAL_WORKSPACE_FOLDER:-.}/data/s3_mock/test-serving:/data
     environment:
@@ -23,3 +20,5 @@ services:
       - APP_ARGS=--keyword_index_type Lucene --text_model 'Dummy' --visual_model 'Dummy' --backend local --remote_data_directory '/data' --local_data_directory '/data' --host 0.0.0.0
       - GUNICORN_BIND=0.0.0.0:8080
     command: ["poetry", "run", "gunicorn", "-c", "gunicorn.conf.py", "scripts.python_helpers.start_api_server:create_app()"]
+    ipc: "host"
+    network_mode: "host"

--- a/scripts/generate_embeddings_docker.sh
+++ b/scripts/generate_embeddings_docker.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This script is a sample of starting the embedding processs using a docker image.
+
+# Build the docker image first using
+# $ docker build -t govscape .
+
+docker run -v ${LOCAL_WORKSPACE_FOLDER:-.}/data:/data --ipc=host --rm -i --gpus all govscape bash <<'EOF'
+
+# Embedding with GPU
+
+poetry run python scripts/python_helpers/run_embedding_pipeline.py --num_pages_to_process 5 \
+    --batch_size 100 --backend 'local' --local_base_dir '/data/s3_mock' --pdf_dir 'archive/PDFs/' \
+    --remote_data_dir "test-serving" --text_model_type 'BGE' --visual_model_type 'CLIP'
+
+# The command above can be modified for different parameters.
+EOF


### PR DESCRIPTION
Adjustments to the docker environments to enable GPU embedding.

CLIP is too large for the default shm size. Here, I've enabled sharing the host interprocess communication for both the dev container and the production image. Alternatively, we could increase the `--shm-size`, to allocate more shared memory for CUDA.

I've included a sample script that invokes the embedding process using a prebuilt docker image. The docker image would replace the VM image for production embedding.

I also made some adjustments to the .dockerignore.