### PR TITLE
Support Multiple Crawls Per PDF

### DIFF
--- a/govscape/govscape/api/endpoints/pages.py
+++ b/govscape/govscape/api/endpoints/pages.py
@@ -1,4 +1,5 @@
 # AI modified: 2026-03-08 f62d40b8
+# AI modified: 2026-03-14 4a6b1b72
 from flask import current_app
 from flask_restx import Namespace, Resource, fields
 
@@ -23,9 +24,12 @@ pages_response = ns.model(
         "crawl_url": fields.String(description="Most recent crawl URL"),
         "crawl_date": fields.String(description="Most recent crawl date"),
         "sub_domain": fields.String(description="Most recent subdomain"),
+        "has_more_crawls": fields.Boolean(
+            description="True when additional crawls exist beyond returned list"
+        ),
         "crawl_instances": fields.List(
             fields.Nested(crawl_instance_model),
-            description="All crawl instances, newest first",
+            description="Most recent crawl instances, newest first",
         ),
     },
 )

--- a/govscape/govscape/api/endpoints/pages.py
+++ b/govscape/govscape/api/endpoints/pages.py
@@ -1,8 +1,18 @@
+# AI modified: 2026-03-08 f62d40b8
 from flask import current_app
 from flask_restx import Namespace, Resource, fields
 
 # Create namespace
 ns = Namespace("pages", description="PDF pages operations")
+
+crawl_instance_model = ns.model(
+    "CrawlInstance",
+    {
+        "crawl_url": fields.String(description="Source URL for this crawl"),
+        "crawl_date": fields.String(description="Crawl date (YYYY-MM-DD)"),
+        "sub_domain": fields.String(description="Subdomain for this crawl"),
+    },
+)
 
 pages_response = ns.model(
     "PagesResponse",
@@ -10,9 +20,13 @@ pages_response = ns.model(
         "images": fields.List(
             fields.String, description="List of image paths for pages"
         ),
-        "crawl_url": fields.String(description="Crawl URL for the PDF"),
-        "crawl_date": fields.String(description="Crawl date for the PDF (YYYY-MM-DD)"),
-        "sub_domain": fields.String(description="Subdomain for the PDF source"),
+        "crawl_url": fields.String(description="Most recent crawl URL"),
+        "crawl_date": fields.String(description="Most recent crawl date"),
+        "sub_domain": fields.String(description="Most recent subdomain"),
+        "crawl_instances": fields.List(
+            fields.Nested(crawl_instance_model),
+            description="All crawl instances, newest first",
+        ),
     },
 )
 

--- a/govscape/govscape/api/endpoints/search.py
+++ b/govscape/govscape/api/endpoints/search.py
@@ -1,3 +1,4 @@
+# AI modified: 2026-03-14 4a6b1b72
 from flask import current_app, request
 from flask_restx import Namespace, Resource, fields
 
@@ -34,9 +35,12 @@ search_result = ns.model(
         "crawl_date": fields.String(description="Most recent crawl date"),
         "crawl_url": fields.String(description="Most recent crawl URL"),
         "sub_domain": fields.String(description="Most recent subdomain"),
+        "has_more_crawls": fields.Boolean(
+            description="True when additional crawls exist beyond returned list"
+        ),
         "crawl_instances": fields.List(
             fields.Nested(search_crawl_instance),
-            description="All crawl instances, newest first",
+            description="Most recent crawl instances, newest first",
         ),
     },
 )

--- a/govscape/govscape/api/endpoints/search.py
+++ b/govscape/govscape/api/endpoints/search.py
@@ -15,6 +15,15 @@ search_input = ns.model(
     },
 )
 
+search_crawl_instance = ns.model(
+    "SearchCrawlInstance",
+    {
+        "crawl_url": fields.String(description="Source URL for this crawl"),
+        "crawl_date": fields.String(description="Crawl date (YYYY-MM-DD)"),
+        "sub_domain": fields.String(description="Subdomain for this crawl"),
+    },
+)
+
 search_result = ns.model(
     "SearchResult",
     {
@@ -22,9 +31,13 @@ search_result = ns.model(
         "page": fields.String(description="Page number"),
         "distance": fields.Float(description="Distance score"),
         "jpeg": fields.String(description="JPEG image path"),
-        "crawl_date": fields.String(description="Crawl date"),
-        "crawl_url": fields.String(description="Crawl URL"),
-        "sub_domain": fields.String(description="Subdomain"),
+        "crawl_date": fields.String(description="Most recent crawl date"),
+        "crawl_url": fields.String(description="Most recent crawl URL"),
+        "sub_domain": fields.String(description="Most recent subdomain"),
+        "crawl_instances": fields.List(
+            fields.Nested(search_crawl_instance),
+            description="All crawl instances, newest first",
+        ),
     },
 )
 

--- a/govscape/govscape/config.py
+++ b/govscape/govscape/config.py
@@ -1,3 +1,4 @@
+# AI modified: 2026-03-14 4a6b1b72
 # These classes should contain all the configuration information necessary for
 # starting the server and serving queries, respectively.
 import numpy as np
@@ -26,7 +27,14 @@ class IndexConfig:
 
 
 class ServerConfig:
-    def __init__(self, index_config: IndexConfig, text_model, visual_model, k=3):
+    def __init__(
+        self,
+        index_config: IndexConfig,
+        text_model,
+        visual_model,
+        k=3,
+        max_crawl_instances=500,
+    ):
         self.index_config = index_config
         self.embedding_directory = index_config.embedding_directory
         self.embedding_img_pg_directory = index_config.embedding_img_pg_directory
@@ -41,6 +49,7 @@ class ServerConfig:
         self.visual_model = visual_model
         self.vector_index_type = index_config.vector_index_type
         self.keyword_index_type = index_config.keyword_index_type
+        self.max_crawl_instances = max_crawl_instances
 
         # define k for top-k
         self.k = k

--- a/govscape/govscape/server.py
+++ b/govscape/govscape/server.py
@@ -1,4 +1,5 @@
 # AI modified: 2026-03-08 f62d40b8
+# AI modified: 2026-03-14 4a6b1b72
 # This file defines the logic for serving requests to the user.
 import math
 import os
@@ -45,6 +46,7 @@ class Server:
         self.vector_index_type = config.vector_index_type
         self.keyword_index_type = config.keyword_index_type
         self.k = config.k
+        self.max_crawl_instances = config.max_crawl_instances
 
         # Index configuration
         self.index_config = config.index_config
@@ -175,6 +177,8 @@ class Server:
                     all_records = sorted(
                         metadata, key=lambda r: r.get("crawl_date", ""), reverse=True
                     )
+                    has_more_crawls = len(all_records) > self.max_crawl_instances
+                    limited_records = all_records[: self.max_crawl_instances]
                     newest = all_records[0]
                     jpeg_file = (
                         self.image_directory
@@ -195,13 +199,14 @@ class Server:
                             "crawl_url": newest.get("crawl_url", ""),
                             "crawl_date": newest.get("crawl_date", ""),
                             "sub_domain": newest.get("sub_domain", ""),
+                            "has_more_crawls": has_more_crawls,
                             "crawl_instances": [
                                 {
                                     "crawl_url": r.get("crawl_url", ""),
                                     "crawl_date": r.get("crawl_date", ""),
                                     "sub_domain": r.get("sub_domain", ""),
                                 }
-                                for r in all_records
+                                for r in limited_records
                             ],
                         }
                     )
@@ -252,6 +257,8 @@ class Server:
         # Sort all crawl records newest-first; crawl_date is YYYY-MM-DD so
         # lexicographic descending sort is correct.
         records = sorted(records, key=lambda r: r.get("crawl_date", ""), reverse=True)
+        has_more_crawls = len(records) > self.max_crawl_instances
+        limited_records = records[: self.max_crawl_instances]
         newest = records[0]
 
         crawl_url = newest.get("crawl_url", "")
@@ -268,7 +275,7 @@ class Server:
                 "crawl_date": r.get("crawl_date", ""),
                 "sub_domain": r.get("sub_domain", ""),
             }
-            for r in records
+            for r in limited_records
         ]
 
         return {
@@ -276,6 +283,7 @@ class Server:
             "crawl_url": crawl_url,
             "crawl_date": crawl_date,
             "sub_domain": sub_domain,
+            "has_more_crawls": has_more_crawls,
             "crawl_instances": crawl_instances,
         }
 

--- a/govscape/govscape/server.py
+++ b/govscape/govscape/server.py
@@ -1,3 +1,4 @@
+# AI modified: 2026-03-08 f62d40b8
 # This file defines the logic for serving requests to the user.
 import math
 import os
@@ -171,7 +172,10 @@ class Server:
             for distance, name, page_num in zip(D, pdf_names, pdf_pages, strict=False):
                 metadata = pdf_metadata.get(name, None)
                 if metadata:
-                    metadata = metadata[0]  # TODO: Handle multiple crawl dates
+                    all_records = sorted(
+                        metadata, key=lambda r: r.get("crawl_date", ""), reverse=True
+                    )
+                    newest = all_records[0]
                     jpeg_file = (
                         self.image_directory
                         + "/"
@@ -188,9 +192,17 @@ class Server:
                             "page": page_num,
                             "distance": float(distance),
                             "jpeg": jpeg_file,
-                            "crawl_url": metadata.get("crawl_url", ""),
-                            "crawl_date": metadata.get("crawl_date", ""),
-                            "sub_domain": metadata.get("sub_domain", ""),
+                            "crawl_url": newest.get("crawl_url", ""),
+                            "crawl_date": newest.get("crawl_date", ""),
+                            "sub_domain": newest.get("sub_domain", ""),
+                            "crawl_instances": [
+                                {
+                                    "crawl_url": r.get("crawl_url", ""),
+                                    "crawl_date": r.get("crawl_date", ""),
+                                    "sub_domain": r.get("sub_domain", ""),
+                                }
+                                for r in all_records
+                            ],
                         }
                     )
             if current_k > min(100000, index.total_entries()):
@@ -229,26 +241,42 @@ class Server:
         """
         Get all page images and metadata for a PDF by pdf_id.
         Returns dict with 'images', 'crawl_url', 'crawl_date', 'sub_domain'
-        keys or error message.
+        (newest crawl), and 'crawl_instances' (all crawls, newest first).
         """
         if not pdf_id:
             return {"error": "Missing 'pdf_id' parameter"}, 400
 
         md = self.metadata_index.search([pdf_id]) or {}
-        first = (md.get(pdf_id) or [{}])[0]
-        crawl_url = first.get("crawl_url", "")
-        crawl_date = first.get("crawl_date", "")
-        sub_domain = first.get("sub_domain", "")
-        page_count = int(first.get("page_count", 0))
+        records = md.get(pdf_id) or [{}]
+
+        # Sort all crawl records newest-first; crawl_date is YYYY-MM-DD so
+        # lexicographic descending sort is correct.
+        records = sorted(records, key=lambda r: r.get("crawl_date", ""), reverse=True)
+        newest = records[0]
+
+        crawl_url = newest.get("crawl_url", "")
+        crawl_date = newest.get("crawl_date", "")
+        sub_domain = newest.get("sub_domain", "")
+        page_count = int(newest.get("page_count", 0))
 
         image_dir = os.path.join(self.image_directory, pdf_id)
         images = [f"{image_dir}/{pdf_id}_{i}.jpeg" for i in range(page_count)]
+
+        crawl_instances = [
+            {
+                "crawl_url": r.get("crawl_url", ""),
+                "crawl_date": r.get("crawl_date", ""),
+                "sub_domain": r.get("sub_domain", ""),
+            }
+            for r in records
+        ]
 
         return {
             "images": images,
             "crawl_url": crawl_url,
             "crawl_date": crawl_date,
             "sub_domain": sub_domain,
+            "crawl_instances": crawl_instances,
         }
 
     def _get_total_pdfs_count(self):

--- a/interface/src/lib/components/PDFPreview.svelte
+++ b/interface/src/lib/components/PDFPreview.svelte
@@ -1,5 +1,6 @@
 <script>
   // AI modified: 2026-03-08 f62d40b8
+  // AI modified: 2026-03-14 4a6b1b72
   import { createEventDispatcher, onDestroy } from 'svelte';
   import { get } from 'svelte/store';
   import { searchStore } from '$lib/stores/search';
@@ -15,8 +16,8 @@
   let error = null;
   let currentPageIndex = 0;
   let totalPages = 0;
-  let crawlHistoryExpanded = false;
-  const CRAWL_COLLAPSE_THRESHOLD = 5;
+  let crawlInstances = [];
+  let hasMoreCrawls = false;
 
   $: crawlInstances = pdfData?.crawlInstances || (
     (pdfData?.crawlUrl || pdfData?.crawlDate || pdfData?.subDomain)
@@ -30,7 +31,7 @@
     loading = true;
     error = null;
     images = [];
-    crawlHistoryExpanded = false;
+    hasMoreCrawls = Boolean(pdfData?.hasMoreCrawls);
 
     try {
       const data = await apiFetch(`/pages/${pdfData.id}`, { method: 'GET' });
@@ -42,6 +43,7 @@
       });
       totalPages = images.length;
       currentPageIndex = parseInt(pdfData.page);
+      hasMoreCrawls = Boolean(data.hasMoreCrawls || pdfData?.hasMoreCrawls);
     } catch (e) {
       error = e.message;
     } finally {
@@ -178,29 +180,29 @@
             <div class="preview-details">
               <div class="crawl-history">
                 <h6 class="crawl-history-title">Crawl History</h6>
-                <table class="crawl-history-table">
-                  <thead>
-                    <tr>
-                      <th>Date</th>
-                      <th>Site</th>
-                      <th>Source</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {#each (crawlHistoryExpanded ? crawlInstances : crawlInstances.slice(0, CRAWL_COLLAPSE_THRESHOLD)) as inst}
-                      <tr>
-                        <td class="crawl-date">{inst.crawlDate || 'N/A'}</td>
-                        <td class="crawl-subdomain">{inst.subDomain || 'N/A'}</td>
-                        <td class="crawl-url"><a href={inst.crawlUrl} target="_blank" rel="noopener noreferrer">{inst.crawlUrl || 'N/A'}</a></td>
-                      </tr>
-                    {/each}
-                  </tbody>
-                </table>
-                {#if crawlInstances.length > CRAWL_COLLAPSE_THRESHOLD}
-                  <button class="crawl-history-toggle" on:click={() => crawlHistoryExpanded = !crawlHistoryExpanded}>
-                    {crawlHistoryExpanded ? 'Show less' : `Show ${crawlInstances.length - CRAWL_COLLAPSE_THRESHOLD} more`}
-                  </button>
+                {#if hasMoreCrawls}
+                  <div class="crawl-history-note">Showing {crawlInstances.length} most recent crawls.</div>
                 {/if}
+                <div class="crawl-history-scroll">
+                  <table class="crawl-history-table">
+                    <thead>
+                      <tr>
+                        <th>Date</th>
+                        <th>Site</th>
+                        <th>Source</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {#each crawlInstances as inst}
+                        <tr>
+                          <td class="crawl-date">{inst.crawlDate || 'N/A'}</td>
+                          <td class="crawl-subdomain">{inst.subDomain || 'N/A'}</td>
+                          <td class="crawl-url"><a href={inst.crawlUrl} target="_blank" rel="noopener noreferrer">{inst.crawlUrl || 'N/A'}</a></td>
+                        </tr>
+                      {/each}
+                    </tbody>
+                  </table>
+                </div>
               </div>
               <div class="action-buttons">
                 <button class="btn btn-primary" on:click={downloadPDF}>
@@ -251,6 +253,19 @@
     color: var(--text-color-primary);
   }
 
+  .crawl-history-note {
+    margin-bottom: 0.4rem;
+    font-size: 0.76rem;
+    color: var(--text-color-secondary);
+  }
+
+  .crawl-history-scroll {
+    max-height: 220px;
+    overflow-y: auto;
+    border: 1px solid var(--preview-border-color);
+    border-radius: 6px;
+  }
+
   .crawl-history-table {
     width: 100%;
     border-collapse: collapse;
@@ -280,17 +295,6 @@
 
   .crawl-url a {
     word-break: break-all;
-  }
-
-  .crawl-history-toggle {
-    margin-top: 4px;
-    background: none;
-    border: none;
-    padding: 0;
-    font-size: 0.78rem;
-    color: var(--color-primary);
-    cursor: pointer;
-    text-decoration: underline;
   }
 
   .modal-backdrop {

--- a/interface/src/lib/components/PDFPreview.svelte
+++ b/interface/src/lib/components/PDFPreview.svelte
@@ -1,4 +1,5 @@
 <script>
+  // AI modified: 2026-03-08 f62d40b8
   import { createEventDispatcher, onDestroy } from 'svelte';
   import { get } from 'svelte/store';
   import { searchStore } from '$lib/stores/search';
@@ -14,6 +15,14 @@
   let error = null;
   let currentPageIndex = 0;
   let totalPages = 0;
+  let crawlHistoryExpanded = false;
+  const CRAWL_COLLAPSE_THRESHOLD = 5;
+
+  $: crawlInstances = pdfData?.crawlInstances || (
+    (pdfData?.crawlUrl || pdfData?.crawlDate || pdfData?.subDomain)
+      ? [{ crawlUrl: pdfData?.crawlUrl || '', crawlDate: pdfData?.crawlDate || '', subDomain: pdfData?.subDomain || '' }]
+      : []
+  );
 
   async function fetchImages() {
     if (!pdfData?.id) return;
@@ -21,6 +30,7 @@
     loading = true;
     error = null;
     images = [];
+    crawlHistoryExpanded = false;
 
     try {
       const data = await apiFetch(`/pages/${pdfData.id}`, { method: 'GET' });
@@ -166,9 +176,32 @@
           </div>
           <aside class="preview-sidebar">
             <div class="preview-details">
-              <div><b>Sub-Domain:</b> {pdfData?.subDomain || 'Not Available'}</div>
-              <div><b>Crawl Date:</b> {pdfData?.crawlDate || 'Not Available'}</div>
-              <div><b>Crawl URL:</b> <a href={pdfData?.crawlUrl || 'Not Available'}>{pdfData?.crawlUrl || 'Not Available'}</a></div>
+              <div class="crawl-history">
+                <h6 class="crawl-history-title">Crawl History</h6>
+                <table class="crawl-history-table">
+                  <thead>
+                    <tr>
+                      <th>Date</th>
+                      <th>Site</th>
+                      <th>Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {#each (crawlHistoryExpanded ? crawlInstances : crawlInstances.slice(0, CRAWL_COLLAPSE_THRESHOLD)) as inst}
+                      <tr>
+                        <td class="crawl-date">{inst.crawlDate || 'N/A'}</td>
+                        <td class="crawl-subdomain">{inst.subDomain || 'N/A'}</td>
+                        <td class="crawl-url"><a href={inst.crawlUrl} target="_blank" rel="noopener noreferrer">{inst.crawlUrl || 'N/A'}</a></td>
+                      </tr>
+                    {/each}
+                  </tbody>
+                </table>
+                {#if crawlInstances.length > CRAWL_COLLAPSE_THRESHOLD}
+                  <button class="crawl-history-toggle" on:click={() => crawlHistoryExpanded = !crawlHistoryExpanded}>
+                    {crawlHistoryExpanded ? 'Show less' : `Show ${crawlInstances.length - CRAWL_COLLAPSE_THRESHOLD} more`}
+                  </button>
+                {/if}
+              </div>
               <div class="action-buttons">
                 <button class="btn btn-primary" on:click={downloadPDF}>
                   <i class="bi bi-download"></i>
@@ -205,6 +238,59 @@
     --preview-border-color: #e0e4e8;
     --preview-spacing-unit: 1rem;
     --preview-border-radius: 8px;
+  }
+
+  .crawl-history {
+    margin-bottom: 0.75rem;
+  }
+
+  .crawl-history-title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+    color: var(--text-color-primary);
+  }
+
+  .crawl-history-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.78rem;
+  }
+
+  .crawl-history-table th {
+    text-align: left;
+    padding: 4px 6px;
+    border-bottom: 2px solid var(--preview-border-color);
+    white-space: nowrap;
+  }
+
+  .crawl-history-table td {
+    padding: 4px 6px;
+    border-bottom: 1px solid var(--preview-border-color);
+    vertical-align: top;
+  }
+
+  .crawl-date {
+    white-space: nowrap;
+  }
+
+  .crawl-subdomain {
+    white-space: nowrap;
+  }
+
+  .crawl-url a {
+    word-break: break-all;
+  }
+
+  .crawl-history-toggle {
+    margin-top: 4px;
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 0.78rem;
+    color: var(--color-primary);
+    cursor: pointer;
+    text-decoration: underline;
   }
 
   .modal-backdrop {

--- a/interface/src/lib/components/ResultsGrid.svelte
+++ b/interface/src/lib/components/ResultsGrid.svelte
@@ -67,7 +67,7 @@
     previousPage = currentPage;
   })();
 
-  function handlePDFSelect(pdf, page, crawlDate, crawlUrl, subDomain) {
+  function handlePDFSelect(pdf, page, crawlDate, crawlUrl, subDomain, crawlInstances) {
     const pdfId = pdf.split('/').pop();
 
     try {
@@ -80,7 +80,7 @@
       });
     } catch (e) {}
 
-    dispatch('pdfSelect', { pdf, page, id: pdfId, crawlDate, crawlUrl, subDomain });
+    dispatch('pdfSelect', { pdf, page, id: pdfId, crawlDate, crawlUrl, subDomain, crawlInstances });
   }
 
   function updatePageInURL(newPage) {
@@ -148,7 +148,7 @@
   <div class="masonry-wrapper" bind:this={gridElement}>
     {#each results as result (result.pdf + result.page)}
     <div class="grid-item">
-      <div class="result-card" on:click={() => handlePDFSelect(result.pdf, result.page, result.crawlDate, result.crawlUrl, result.subDomain)}>
+      <div class="result-card" on:click={() => handlePDFSelect(result.pdf, result.page, result.crawlDate, result.crawlUrl, result.subDomain, result.crawlInstances)}>
         <div class="image-container">
           <img
             src={result.jpeg}

--- a/interface/src/lib/components/ResultsGrid.svelte
+++ b/interface/src/lib/components/ResultsGrid.svelte
@@ -1,4 +1,5 @@
 <script>
+  // AI modified: 2026-03-14 4a6b1b72
   import { createEventDispatcher, onMount, afterUpdate, onDestroy } from 'svelte';
   import Masonry from 'masonry-layout';
   import { searchStore, searchActions } from '$lib/stores/search';
@@ -67,7 +68,7 @@
     previousPage = currentPage;
   })();
 
-  function handlePDFSelect(pdf, page, crawlDate, crawlUrl, subDomain, crawlInstances) {
+  function handlePDFSelect(pdf, page, crawlDate, crawlUrl, subDomain, crawlInstances, hasMoreCrawls) {
     const pdfId = pdf.split('/').pop();
 
     try {
@@ -80,7 +81,7 @@
       });
     } catch (e) {}
 
-    dispatch('pdfSelect', { pdf, page, id: pdfId, crawlDate, crawlUrl, subDomain, crawlInstances });
+    dispatch('pdfSelect', { pdf, page, id: pdfId, crawlDate, crawlUrl, subDomain, crawlInstances, hasMoreCrawls });
   }
 
   function updatePageInURL(newPage) {
@@ -148,7 +149,7 @@
   <div class="masonry-wrapper" bind:this={gridElement}>
     {#each results as result (result.pdf + result.page)}
     <div class="grid-item">
-      <div class="result-card" on:click={() => handlePDFSelect(result.pdf, result.page, result.crawlDate, result.crawlUrl, result.subDomain, result.crawlInstances)}>
+      <div class="result-card" on:click={() => handlePDFSelect(result.pdf, result.page, result.crawlDate, result.crawlUrl, result.subDomain, result.crawlInstances, result.hasMoreCrawls)}>
         <div class="image-container">
           <img
             src={result.jpeg}

--- a/interface/src/routes/preview/[id]/+page.svelte
+++ b/interface/src/routes/preview/[id]/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  // AI modified: 2026-03-08 f62d40b8
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
@@ -16,6 +17,9 @@
   let pdfSubDomain = '';
   let pdfCrawlDate = '';
   let pdfCrawlUrl = '';
+  let crawlInstances = [];
+  let crawlHistoryExpanded = false;
+  const CRAWL_COLLAPSE_THRESHOLD = 5;
 
   async function fetchImages() {
     if (!id) return;
@@ -35,6 +39,10 @@
       if (!pdfSubDomain) pdfSubDomain = data.subDomain || '';
       if (!pdfCrawlDate) pdfCrawlDate = data.crawlDate || '';
       if (!pdfCrawlUrl) pdfCrawlUrl = data.crawlUrl || '';
+      crawlInstances = data.crawlInstances || [
+        { crawlUrl: pdfCrawlUrl, crawlDate: pdfCrawlDate, subDomain: pdfSubDomain }
+      ];
+      crawlHistoryExpanded = false;
 
       const p = parseInt($page.url.searchParams.get('page') || '1', 10);
       const idx = Number.isFinite(p) ? Math.max(0, Math.min(p - 1, Math.max(totalPages - 1, 0))) : 0;
@@ -164,14 +172,30 @@
         <aside class="preview-sidebar">
           <div class="preview-details">
             <h5 class="modal-title">{(pdfCrawlUrl && pdfCrawlUrl.split('/').pop().replaceAll("\%20", " ")) || (id && id.split('/').pop().replaceAll("%20", " "))}</h5>
-            <div><b>Sub-Domain:</b> {pdfSubDomain || 'Not Available'}</div>
-            <div><b>Crawl Date:</b> {pdfCrawlDate || 'Not Available'}</div>
-            <div>
-              <b>Crawl URL:</b>
-              {#if pdfCrawlUrl}
-                <a href={pdfCrawlUrl}>{pdfCrawlUrl}</a>
-              {:else}
-                Not Available
+            <div class="crawl-history">
+              <h6 class="crawl-history-title">Crawl History</h6>
+              <table class="crawl-history-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Site</th>
+                    <th>Source</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each (crawlHistoryExpanded ? crawlInstances : crawlInstances.slice(0, CRAWL_COLLAPSE_THRESHOLD)) as inst}
+                    <tr>
+                    <td class="crawl-date">{inst.crawlDate || 'N/A'}</td>
+                    <td class="crawl-subdomain">{inst.subDomain || 'N/A'}</td>
+                    <td class="crawl-url"><a href={inst.crawlUrl} target="_blank" rel="noopener noreferrer">{inst.crawlUrl || 'N/A'}</a></td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+              {#if crawlInstances.length > CRAWL_COLLAPSE_THRESHOLD}
+                <button class="crawl-history-toggle" on:click={() => crawlHistoryExpanded = !crawlHistoryExpanded}>
+                  {crawlHistoryExpanded ? 'Show less' : `Show ${crawlInstances.length - CRAWL_COLLAPSE_THRESHOLD} more`}
+                </button>
               {/if}
             </div>
             <div class="action-buttons">
@@ -209,6 +233,59 @@
     --preview-border-color: #e0e4e8;
     --preview-spacing-unit: 1rem;
     --preview-border-radius: 8px;
+  }
+
+  .crawl-history {
+    margin-bottom: 0.75rem;
+  }
+
+  .crawl-history-title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+    color: var(--text-color-primary);
+  }
+
+  .crawl-history-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.78rem;
+  }
+
+  .crawl-history-table th {
+    text-align: left;
+    padding: 4px 6px;
+    border-bottom: 2px solid var(--preview-border-color);
+    white-space: nowrap;
+  }
+
+  .crawl-history-table td {
+    padding: 4px 6px;
+    border-bottom: 1px solid var(--preview-border-color);
+    vertical-align: top;
+  }
+
+  .crawl-date {
+    white-space: nowrap;
+  }
+
+  .crawl-subdomain {
+    white-space: nowrap;
+  }
+
+  .crawl-url a {
+    word-break: break-all;
+  }
+
+  .crawl-history-toggle {
+    margin-top: 4px;
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 0.78rem;
+    color: var(--color-primary);
+    cursor: pointer;
+    text-decoration: underline;
   }
 
   main {

--- a/interface/src/routes/preview/[id]/+page.svelte
+++ b/interface/src/routes/preview/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   // AI modified: 2026-03-08 f62d40b8
+  // AI modified: 2026-03-14 4a6b1b72
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
@@ -18,8 +19,7 @@
   let pdfCrawlDate = '';
   let pdfCrawlUrl = '';
   let crawlInstances = [];
-  let crawlHistoryExpanded = false;
-  const CRAWL_COLLAPSE_THRESHOLD = 5;
+  let hasMoreCrawls = false;
 
   async function fetchImages() {
     if (!id) return;
@@ -39,10 +39,10 @@
       if (!pdfSubDomain) pdfSubDomain = data.subDomain || '';
       if (!pdfCrawlDate) pdfCrawlDate = data.crawlDate || '';
       if (!pdfCrawlUrl) pdfCrawlUrl = data.crawlUrl || '';
+      hasMoreCrawls = Boolean(data.hasMoreCrawls);
       crawlInstances = data.crawlInstances || [
         { crawlUrl: pdfCrawlUrl, crawlDate: pdfCrawlDate, subDomain: pdfSubDomain }
       ];
-      crawlHistoryExpanded = false;
 
       const p = parseInt($page.url.searchParams.get('page') || '1', 10);
       const idx = Number.isFinite(p) ? Math.max(0, Math.min(p - 1, Math.max(totalPages - 1, 0))) : 0;
@@ -174,29 +174,29 @@
             <h5 class="modal-title">{(pdfCrawlUrl && pdfCrawlUrl.split('/').pop().replaceAll("\%20", " ")) || (id && id.split('/').pop().replaceAll("%20", " "))}</h5>
             <div class="crawl-history">
               <h6 class="crawl-history-title">Crawl History</h6>
-              <table class="crawl-history-table">
-                <thead>
-                  <tr>
-                    <th>Date</th>
-                    <th>Site</th>
-                    <th>Source</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {#each (crawlHistoryExpanded ? crawlInstances : crawlInstances.slice(0, CRAWL_COLLAPSE_THRESHOLD)) as inst}
-                    <tr>
-                    <td class="crawl-date">{inst.crawlDate || 'N/A'}</td>
-                    <td class="crawl-subdomain">{inst.subDomain || 'N/A'}</td>
-                    <td class="crawl-url"><a href={inst.crawlUrl} target="_blank" rel="noopener noreferrer">{inst.crawlUrl || 'N/A'}</a></td>
-                    </tr>
-                  {/each}
-                </tbody>
-              </table>
-              {#if crawlInstances.length > CRAWL_COLLAPSE_THRESHOLD}
-                <button class="crawl-history-toggle" on:click={() => crawlHistoryExpanded = !crawlHistoryExpanded}>
-                  {crawlHistoryExpanded ? 'Show less' : `Show ${crawlInstances.length - CRAWL_COLLAPSE_THRESHOLD} more`}
-                </button>
+              {#if hasMoreCrawls}
+                <div class="crawl-history-note">Showing {crawlInstances.length} most recent crawls.</div>
               {/if}
+              <div class="crawl-history-scroll">
+                <table class="crawl-history-table">
+                  <thead>
+                    <tr>
+                      <th>Date</th>
+                      <th>Site</th>
+                      <th>Source</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {#each crawlInstances as inst}
+                      <tr>
+                      <td class="crawl-date">{inst.crawlDate || 'N/A'}</td>
+                      <td class="crawl-subdomain">{inst.subDomain || 'N/A'}</td>
+                      <td class="crawl-url"><a href={inst.crawlUrl} target="_blank" rel="noopener noreferrer">{inst.crawlUrl || 'N/A'}</a></td>
+                      </tr>
+                    {/each}
+                  </tbody>
+                </table>
+              </div>
             </div>
             <div class="action-buttons">
               <button class="btn btn-primary" on:click={downloadPDF}>
@@ -246,6 +246,19 @@
     color: var(--text-color-primary);
   }
 
+  .crawl-history-note {
+    margin-bottom: 0.4rem;
+    font-size: 0.76rem;
+    color: var(--text-color-secondary);
+  }
+
+  .crawl-history-scroll {
+    max-height: 220px;
+    overflow-y: auto;
+    border: 1px solid var(--preview-border-color);
+    border-radius: 6px;
+  }
+
   .crawl-history-table {
     width: 100%;
     border-collapse: collapse;
@@ -275,17 +288,6 @@
 
   .crawl-url a {
     word-break: break-all;
-  }
-
-  .crawl-history-toggle {
-    margin-top: 4px;
-    background: none;
-    border: none;
-    padding: 0;
-    font-size: 0.78rem;
-    color: var(--color-primary);
-    cursor: pointer;
-    text-decoration: underline;
   }
 
   main {

--- a/interface/src/routes/search/+page.svelte
+++ b/interface/src/routes/search/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  // AI modified: 2026-03-14 4a6b1b72
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
   import { searchStore, searchActions } from '$lib/stores/search';
@@ -11,8 +12,8 @@
   let selectedPDF = null;
 
   function handlePDFSelect(event) {
-    const { id, page, crawlDate, crawlUrl, subDomain, crawlInstances } = event.detail || {};
-    selectedPDF = { id, page, crawlDate, crawlUrl, subDomain, crawlInstances };
+    const { id, page, crawlDate, crawlUrl, subDomain, crawlInstances, hasMoreCrawls } = event.detail || {};
+    selectedPDF = { id, page, crawlDate, crawlUrl, subDomain, crawlInstances, hasMoreCrawls };
     shouldShowPreview = true;
   }
 

--- a/interface/src/routes/search/+page.svelte
+++ b/interface/src/routes/search/+page.svelte
@@ -11,8 +11,8 @@
   let selectedPDF = null;
 
   function handlePDFSelect(event) {
-    const { id, page, crawlDate, crawlUrl, subDomain } = event.detail || {};
-    selectedPDF = { id, page, crawlDate, crawlUrl, subDomain };
+    const { id, page, crawlDate, crawlUrl, subDomain, crawlInstances } = event.detail || {};
+    selectedPDF = { id, page, crawlDate, crawlUrl, subDomain, crawlInstances };
     shouldShowPreview = true;
   }
 

--- a/scripts/python_helpers/start_api_server.py
+++ b/scripts/python_helpers/start_api_server.py
@@ -1,3 +1,4 @@
+# AI modified: 2026-03-14 4a6b1b72
 import argparse
 import os
 import shlex
@@ -47,6 +48,12 @@ def _get_arg_parser():
         "-k", "--top-k", type=int, default=20, help="Number of top results to return"
     )
     parser.add_argument(
+        "--max_crawl_instances",
+        type=int,
+        default=500,
+        help="Maximum number of crawl instances returned per PDF",
+    )
+    parser.add_argument(
         "-i",
         "--vector_index_type",
         default="Memory",
@@ -93,7 +100,11 @@ def _build_app_from_args(args):
     )
 
     server_config = gs.ServerConfig(
-        index_config, text_model, visual_model, k=args.top_k
+        index_config,
+        text_model,
+        visual_model,
+        k=args.top_k,
+        max_crawl_instances=args.max_crawl_instances,
     )
     return gs.Server(server_config)
 


### PR DESCRIPTION
Implements #38 

Adds table to PDFPreview to display all crawl instances a PDF has been scraped. If there are more than 5, then it collapses the list by default. Front end remains backwards compatible with existing server API.

<img width="732" height="566" alt="image" src="https://github.com/user-attachments/assets/7b5afa57-1ead-456f-9635-bc2408b57c45" />


/preview (before and after)
<img width="2535" height="1214" alt="image" src="https://github.com/user-attachments/assets/0829626e-742f-42c6-8f24-aaaa32cebecc" />

<img width="2534" height="1247" alt="image" src="https://github.com/user-attachments/assets/13f3e8a4-5262-4553-9ba8-8e4b61a44b9e" />



A new config argument adds a hard cap on the number of crawls returned by the API. Default is 500, shown here, demonstrated here at 1. If there are more than the cap returned, then the API sets a flag in the response so the UI knows to add the message.
<img width="710" height="370" alt="image" src="https://github.com/user-attachments/assets/c099c64a-26dd-480e-a090-1efd1ea49d59" />


Adds every crawl instances to a new response field on the backend's search and pages APIs. The original response fields are retained for the most recent crawl for backwards compatibility.