### PR TITLE
Add blacklist functionality

### DIFF
--- a/DATA_MODEL.md
+++ b/DATA_MODEL.md
@@ -14,6 +14,9 @@ The data in the S3 Bucket should be laid out as follows:
 * {test,dev,prod}-serving/metadata/{digest}/metadata.json
 * {test,dev,prod}-serving/performance/performance_{job_name}.json
 * {test,dev,prod}-serving/checkpoints/checkpoint_{job_name/server_id}.json
+* {test,dev,prod}-serving/blacklist.txt
+
+The blacklist.txt file is optional. When present, it contains PDF digests (one per line) to hide from all search results and `/pages/<pdf_id>` lookups, used for privacy and copyright takedown requests. Blank lines and lines starting with `#` are ignored, so operational annotations like `# DMCA ticket-1234` are allowed.
 
 The pdf_metadata.parquet file has the following columns:
 

--- a/govscape/govscape/config.py
+++ b/govscape/govscape/config.py
@@ -15,6 +15,7 @@ class IndexConfig:
         self.image_directory = data_dir + "/img"
         self.metadata_directory = data_dir + "/metadata"
         self.stats_file = data_dir + "/total_pdfs.txt"
+        self.blacklist_file = data_dir + "/blacklist.txt"
         if vector_index_type not in ["Memory", "Disk"]:
             raise ValueError("vector_index_type must be either 'Memory' or 'Disk'")
         self.vector_index_type = vector_index_type
@@ -45,6 +46,7 @@ class ServerConfig:
         self.image_directory = index_config.image_directory
         self.metadata_directory = index_config.metadata_directory
         self.stats_file = index_config.stats_file
+        self.blacklist_file = index_config.blacklist_file
         self.text_model = text_model
         self.visual_model = visual_model
         self.vector_index_type = index_config.vector_index_type

--- a/govscape/govscape/server.py
+++ b/govscape/govscape/server.py
@@ -290,7 +290,14 @@ class Server:
             return {"error": "Missing 'pdf_id' parameter"}, 400
 
         if pdf_id in self.blacklist:
-            return {"error": "PDF not found"}, 404
+            return {
+                "images": [],
+                "crawl_url": "",
+                "crawl_date": "",
+                "sub_domain": "",
+                "has_more_crawls": False,
+                "crawl_instances": [],
+            }
 
         md = self.metadata_index.search([pdf_id]) or {}
         records = md.get(pdf_id) or [{}]

--- a/govscape/govscape/server.py
+++ b/govscape/govscape/server.py
@@ -44,6 +44,7 @@ class Server:
         self.index_metadata_directory = config.index_metadata_directory
         self.image_directory = config.image_directory
         self.stats_file = config.stats_file
+        self.blacklist_file = config.blacklist_file
         self.vector_index_type = config.vector_index_type
         self.keyword_index_type = config.keyword_index_type
         self.k = config.k
@@ -86,6 +87,8 @@ class Server:
         self.metadata_index = SQLiteMetadataIndex(self.index_metadata_directory)
         self.metadata_index.load_index()
 
+        self.blacklist: set[str] = self._load_blacklist()
+
         self.s3 = boto3.client("s3")
 
         # Get the absolute path to the build directory
@@ -115,6 +118,24 @@ class Server:
 
         self.app.server = self  # type: ignore[attr-defined]
         self.api = init_api(self.app)
+
+    def _load_blacklist(self) -> set[str]:
+        path = self.blacklist_file
+        if not os.path.exists(path):
+            print(f"No blacklist file at {path}; starting with empty blacklist")
+            return set()
+        try:
+            with open(path, encoding="utf-8") as f:
+                entries = {
+                    line.strip()
+                    for line in f
+                    if line.strip() and not line.strip().startswith("#")
+                }
+            print(f"Loaded {len(entries)} blacklist entries")
+            return entries
+        except OSError as e:
+            print(f"Warning: failed to read blacklist at {path}: {e}")
+            return set()
 
     @staticmethod
     def deduplicate_responses(D, names, pages):
@@ -161,6 +182,19 @@ class Server:
             D, pdf_names, pdf_pages = self.deduplicate_responses(
                 D, pdf_names, pdf_pages
             )
+
+            if self.blacklist:
+                filtered = [
+                    (d, n, p)
+                    for d, n, p in zip(D, pdf_names, pdf_pages, strict=False)
+                    if n not in self.blacklist
+                ]
+                if filtered:
+                    D, pdf_names, pdf_pages = (
+                        list(x) for x in zip(*filtered, strict=False)
+                    )
+                else:
+                    D, pdf_names, pdf_pages = [], [], []
 
             print(f"Index Search took {time.time() - start} seconds")
             print(
@@ -254,6 +288,9 @@ class Server:
         """
         if not pdf_id:
             return {"error": "Missing 'pdf_id' parameter"}, 400
+
+        if pdf_id in self.blacklist:
+            return {"error": "PDF not found"}, 404
 
         md = self.metadata_index.search([pdf_id]) or {}
         records = md.get(pdf_id) or [{}]

--- a/govscape/tests/test_serving.py
+++ b/govscape/tests/test_serving.py
@@ -203,11 +203,18 @@ def test_search_filters_blacklisted_pdfs_keyword(server_fixture_with_blacklist):
     ]
 
 
-def test_pdf_pages_blacklisted_returns_404(server_fixture_with_blacklist):
+def test_pdf_pages_blacklisted_returns_empty_200(server_fixture_with_blacklist):
     server, _ = server_fixture_with_blacklist
     result = server.pdf_pages("doc_0.pdf")
 
-    assert result == ({"error": "PDF not found"}, 404)
+    assert result == {
+        "images": [],
+        "crawl_url": "",
+        "crawl_date": "",
+        "sub_domain": "",
+        "has_more_crawls": False,
+        "crawl_instances": [],
+    }
 
 
 def test_pdf_pages_non_blacklisted_unaffected(server_fixture_with_blacklist):

--- a/govscape/tests/test_serving.py
+++ b/govscape/tests/test_serving.py
@@ -88,8 +88,7 @@ class DummyMetadataIndex:
         }
 
 
-@pytest.fixture()
-def server_fixture(tmp_path, monkeypatch):
+def _build_server_fixture(tmp_path, monkeypatch, blacklist_text: str | None = None):
     data_dir = tmp_path / "data"
     (data_dir / "embeddings").mkdir(parents=True)
     (data_dir / "embeddings_img_pg").mkdir(parents=True)
@@ -100,6 +99,8 @@ def server_fixture(tmp_path, monkeypatch):
     (data_dir / "img").mkdir(parents=True)
     (data_dir / "metadata").mkdir(parents=True)
     (data_dir / "total_pdfs.txt").write_text("0")
+    if blacklist_text is not None:
+        (data_dir / "blacklist.txt").write_text(blacklist_text)
 
     monkeypatch.setattr("govscape.server.FAISSIndex", DummyVectorIndex)
     monkeypatch.setattr("govscape.server.LanceDBKeywordIndex", DummyKeywordIndex)
@@ -116,6 +117,17 @@ def server_fixture(tmp_path, monkeypatch):
 
     server_config = ServerConfig(index_config, text_model, visual_model, k=3)
     return Server(server_config), index_config
+
+
+@pytest.fixture()
+def server_fixture(tmp_path, monkeypatch):
+    return _build_server_fixture(tmp_path, monkeypatch)
+
+
+@pytest.fixture()
+def server_fixture_with_blacklist(tmp_path, monkeypatch):
+    blacklist_text = "doc_0.pdf\n# takedown ticket-1234\n\n  keyword_doc_0.pdf  \n"
+    return _build_server_fixture(tmp_path, monkeypatch, blacklist_text=blacklist_text)
 
 
 def test_server_initialization(server_fixture):
@@ -157,3 +169,50 @@ def test_server_keyword_search_uses_keyword_index(server_fixture):
         "keyword_doc_1.pdf",
         "keyword_doc_2.pdf",
     ]
+
+
+def test_blacklist_missing_file_is_empty(server_fixture):
+    server, _ = server_fixture
+    assert server.blacklist == set()
+
+
+def test_blacklist_loads_from_file(server_fixture_with_blacklist):
+    server, _ = server_fixture_with_blacklist
+    assert server.blacklist == {"doc_0.pdf", "keyword_doc_0.pdf"}
+
+
+def test_search_filters_blacklisted_pdfs_textual(server_fixture_with_blacklist):
+    server, _ = server_fixture_with_blacklist
+    response = server.search(Query("test", search_type="textual"))
+
+    returned = [r["pdf"] for r in response.results]
+    assert "doc_0.pdf" not in returned
+    assert len(response.results) == server.config.k
+
+
+def test_search_filters_blacklisted_pdfs_keyword(server_fixture_with_blacklist):
+    server, _ = server_fixture_with_blacklist
+    response = server.search(Query("site:gov", search_type="keyword"))
+
+    returned = [r["pdf"] for r in response.results]
+    assert "keyword_doc_0.pdf" not in returned
+    assert returned == [
+        "keyword_doc_1.pdf",
+        "keyword_doc_2.pdf",
+        "keyword_doc_3.pdf",
+    ]
+
+
+def test_pdf_pages_blacklisted_returns_404(server_fixture_with_blacklist):
+    server, _ = server_fixture_with_blacklist
+    result = server.pdf_pages("doc_0.pdf")
+
+    assert result == ({"error": "PDF not found"}, 404)
+
+
+def test_pdf_pages_non_blacklisted_unaffected(server_fixture_with_blacklist):
+    server, _ = server_fixture_with_blacklist
+    result = server.pdf_pages("doc_1.pdf")
+
+    assert isinstance(result, dict)
+    assert "images" in result

--- a/scripts/python_helpers/run_gunicorn.py
+++ b/scripts/python_helpers/run_gunicorn.py
@@ -60,6 +60,14 @@ def download_indices(args):
                 finished = True
                 print(f"Finished downloading indices from {remote_dir} to {local_dir}")
 
+    remote_blacklist = os.path.join(REMOTE_DATA_DIR, "blacklist.txt")
+    local_blacklist = os.path.join(LOCAL_DATA_DIR, "blacklist.txt")
+    try:
+        data_loader.download_file(remote_blacklist, local_blacklist)
+        print(f"Downloaded blacklist: {remote_blacklist} -> {local_blacklist}")
+    except Exception as e:
+        print(f"No blacklist file to download ({e}); proceeding without one")
+
 
 def main():
     if "--" in sys.argv:


### PR DESCRIPTION
This PR adds the option to add a blacklist.txt file to the s3 directory (prod-serving,dev-serving,etc.) that stores digests which we do not want to show in the front end.