### PR TITLE
Expand the use of Data Model

### DIFF
--- a/govscape/govscape/config.py
+++ b/govscape/govscape/config.py
@@ -22,6 +22,42 @@ class DataModel:
         self.stats_file = os.path.join(data_dir, "total_pdfs.txt")
         self.blacklist_file = os.path.join(data_dir, "blacklist.txt")
 
+    # Per-PDF subdirectory helpers
+
+    def txt_pdf_directory(self, digest: str) -> str:
+        return os.path.join(self.txt_directory, digest)
+
+    def img_pdf_directory(self, digest: str) -> str:
+        return os.path.join(self.image_directory, digest)
+
+    def embedding_pdf_directory(self, digest: str) -> str:
+        return os.path.join(self.embedding_directory, digest)
+
+    def embedding_img_pg_pdf_directory(self, digest: str) -> str:
+        return os.path.join(self.embedding_img_pg_directory, digest)
+
+    def metadata_pdf_directory(self, digest: str) -> str:
+        return os.path.join(self.metadata_directory, digest)
+
+    # Per-page file helpers
+
+    def txt_page_path(self, digest: str, pg_no: int) -> str:
+        return os.path.join(self.txt_directory, digest, f"{digest}_{pg_no}.txt")
+
+    def img_page_path(self, digest: str, pg_no: int) -> str:
+        return os.path.join(self.image_directory, digest, f"{digest}_{pg_no}.jpeg")
+
+    def embedding_page_path(self, digest: str, pg_no: int) -> str:
+        return os.path.join(self.embedding_directory, digest, f"{digest}_{pg_no}.npy")
+
+    def embedding_img_pg_page_path(self, digest: str, pg_no: int) -> str:
+        return os.path.join(
+            self.embedding_img_pg_directory, digest, f"{digest}_{pg_no}.npy"
+        )
+
+    def metadata_file_path(self, digest: str) -> str:
+        return os.path.join(self.metadata_directory, digest, "metadata.json")
+
 
 class ServerConfig:
     def __init__(

--- a/govscape/govscape/config.py
+++ b/govscape/govscape/config.py
@@ -58,6 +58,16 @@ class DataModel:
     def metadata_file_path(self, digest: str) -> str:
         return os.path.join(self.metadata_directory, digest, "metadata.json")
 
+    def checkpoint_file_path(self, checkpoint_prefix: str) -> str:
+        return os.path.join(
+            self.checkpoints_directory, f"{checkpoint_prefix}_checkpoint.json"
+        )
+
+    def performance_file_path(self, performance_prefix: str) -> str:
+        return os.path.join(
+            self.performance_directory, f"{performance_prefix}_performance.json"
+        )
+
 
 class ServerConfig:
     def __init__(

--- a/govscape/govscape/pdf_processing_pipeline.py
+++ b/govscape/govscape/pdf_processing_pipeline.py
@@ -2,6 +2,7 @@ import logging
 import os
 import time
 
+from .config import DataModel
 from .processing import (
     PageImageEmbeddingStage,
     PDFExtractionStage,
@@ -12,19 +13,12 @@ from .processing import (
 class PDFProcessingPipeline:
     def __init__(
         self,
-        pdf_directory: str,
         data_dir: str,
         text_model_type: str,
         visual_model_type: str,
     ):
-        self.pdfs_path = pdf_directory
-        self.txts_path = data_dir + "/txt"
-        self.img_path = data_dir + "/img"
-        self.embeddings_path = data_dir + "/embeddings"
-        self.embeddings_img_path = data_dir + "/embeddings_img_pg"
-        self.index_keyword_directory = data_dir + "/index_keyword"
-        self.metadata_dir = data_dir + "/metadata"
-        self.cpu_count = os.cpu_count()
+        self.data_model = DataModel(data_dir)
+        self.cpu_count = os.cpu_count() or 1
         self.text_model_type = text_model_type
         self.visual_model_type = visual_model_type
 
@@ -35,7 +29,6 @@ class PDFProcessingPipeline:
         do_img_embedding: bool,
         do_metadata_collection: bool,
     ):
-
         run_extraction = do_text_embedding or do_img_embedding or do_metadata_collection
 
         time1 = time.time()
@@ -43,10 +36,7 @@ class PDFProcessingPipeline:
         if run_extraction:
             logging.info("Converting pdfs to txts and page images")
             pdf_extraction_stage = PDFExtractionStage(
-                pdfs_path=self.pdfs_path,
-                txts_path=self.txts_path,
-                img_path=self.img_path,
-                metadata_dir=self.metadata_dir,
+                data_model=self.data_model,
                 pdf_files=pdf_files,
                 cpu_count=self.cpu_count,
             )
@@ -60,8 +50,7 @@ class PDFProcessingPipeline:
         if do_text_embedding:
             logging.info("Converting txts to embeddings")
             text_embedding_stage = TextEmbeddingStage(
-                txts_path=self.txts_path,
-                embeddings_path=self.embeddings_path,
+                data_model=self.data_model,
                 model_type=self.text_model_type,
             )
             text_embedding_stage.validate()
@@ -71,8 +60,7 @@ class PDFProcessingPipeline:
         if do_img_embedding:
             logging.info("Converting imgs to embeddings")
             page_image_embedding_stage = PageImageEmbeddingStage(
-                img_path=self.img_path,
-                embeddings_img_path=self.embeddings_img_path,
+                data_model=self.data_model,
                 model_type=self.visual_model_type,
                 cpu_count=self.cpu_count,
             )

--- a/govscape/govscape/processing/page_image_embedding_stage.py
+++ b/govscape/govscape/processing/page_image_embedding_stage.py
@@ -4,6 +4,7 @@ from multiprocessing import get_context
 
 import numpy as np
 
+from ..config import DataModel
 from ..visual_embedding_models import (
     CLIP_VisualEmbeddingModel,
     Dummy_VisualEmbeddingModel,
@@ -26,34 +27,31 @@ def _build_visual_model(model_type):
 
 
 class PageImageEmbeddingStage(ProcessingStage):
-    def __init__(self, img_path, embeddings_img_path, model_type, cpu_count):
-        self.img_path = img_path
-        self.embeddings_img_path = embeddings_img_path
+    def __init__(self, data_model: DataModel, model_type: str, cpu_count: int):
+        self.data_model = data_model
         self.model = _build_visual_model(model_type)
         self.cpu_count = cpu_count
 
     def validate(self) -> None:
-        if not os.path.isdir(self.img_path):
-            raise ValueError(f"Image input directory does not exist: {self.img_path}")
+        if not os.path.isdir(self.data_model.image_directory):
+            raise ValueError(
+                f"Image input directory does not exist: \
+                            {self.data_model.image_directory}"
+            )
 
     def run(self):
-        os.makedirs(self.embeddings_img_path, exist_ok=True)
+        os.makedirs(self.data_model.embedding_img_pg_directory, exist_ok=True)
         img_paths = []
         embedding_paths = []
-        for img_subdir in os.scandir(self.img_path):
+        for img_subdir in os.scandir(self.data_model.image_directory):
             if img_subdir.is_dir():
-                os.makedirs(
-                    os.path.join(self.embeddings_img_path, img_subdir.name),
-                    exist_ok=True,
-                )
+                digest = img_subdir.name
+                embed_dir = self.data_model.embedding_img_pg_pdf_directory(digest)
+                os.makedirs(embed_dir, exist_ok=True)
                 for img_file in os.listdir(img_subdir.path):
                     img_paths.append(os.path.join(img_subdir.path, img_file))
                     embedding_paths.append(
-                        os.path.join(
-                            self.embeddings_img_path,
-                            img_subdir.name,
-                            os.path.splitext(img_file)[0] + ".npy",
-                        )
+                        os.path.join(embed_dir, os.path.splitext(img_file)[0] + ".npy")
                     )
 
         logging.info(f"Embedding {len(img_paths)} images")

--- a/govscape/govscape/processing/pdf_extraction_stage.py
+++ b/govscape/govscape/processing/pdf_extraction_stage.py
@@ -4,18 +4,16 @@ from multiprocessing import get_context
 
 import pypdfium2
 
+from ..config import DataModel
 from .processing_stage import ProcessingStage
 
 
-def _convert_single_pdf(txts_path, imgs_path, pdfs_path, metadata_dir, pdf_file):
+def _convert_single_pdf(data_model, pdf_file):
     pdf_name = os.path.splitext(os.path.basename(pdf_file))[0]
-    pdf_path = os.path.join(pdfs_path, pdf_file)
-    pdf_txt_subdir = os.path.join(txts_path, pdf_name)
-    pdf_img_subdir = os.path.join(imgs_path, pdf_name)
-    os.makedirs(pdf_txt_subdir, exist_ok=True)
-    os.makedirs(pdf_img_subdir, exist_ok=True)
+    os.makedirs(data_model.txt_pdf_directory(pdf_name), exist_ok=True)
+    os.makedirs(data_model.img_pdf_directory(pdf_name), exist_ok=True)
     try:
-        pdf = pypdfium2.PdfDocument(pdf_path)
+        pdf = pypdfium2.PdfDocument(pdf_file)
         num_pages = len(pdf)
         gov_name = pdf.get_metadata_value("Title")
 
@@ -28,12 +26,8 @@ def _convert_single_pdf(txts_path, imgs_path, pdfs_path, metadata_dir, pdf_file)
         json_data["gov_name"] = gov_name
         json_data["timestamp"] = timestamp
         json_data["num_pages"] = num_pages
-        pdf_metadata_dir = os.path.join(
-            metadata_dir, os.path.splitext(os.path.basename(pdf_file))[0]
-        )
-        os.makedirs(pdf_metadata_dir, exist_ok=True)
-        json_file_path = os.path.join(pdf_metadata_dir, "metadata.json")
-        with open(json_file_path, "w") as json_file:
+        os.makedirs(data_model.metadata_pdf_directory(pdf_name), exist_ok=True)
+        with open(data_model.metadata_file_path(pdf_name), "w") as json_file:
             json.dump(json_data, json_file, indent=4)
 
         text = []
@@ -48,47 +42,36 @@ def _convert_single_pdf(txts_path, imgs_path, pdfs_path, metadata_dir, pdf_file)
         return False
 
     for page_num, page_text in enumerate(text):
-        txt_file_path = os.path.join(pdf_txt_subdir, f"{pdf_name}_{page_num}.txt")
         if page_text and len(page_text) != 0:
-            with open(txt_file_path, "w", encoding="utf-8") as text_file:
+            with open(
+                data_model.txt_page_path(pdf_name, page_num), "w", encoding="utf-8"
+            ) as text_file:
                 text_file.write(page_text)
 
-        img_file_path = os.path.join(pdf_img_subdir, f"{pdf_name}_{page_num}.jpeg")
-        image = images[page_num]
-        image.save(img_file_path, format="JPEG")
+        images[page_num].save(
+            data_model.img_page_path(pdf_name, page_num), format="JPEG"
+        )
     return True
 
 
 class PDFExtractionStage(ProcessingStage):
-    def __init__(
-        self, pdfs_path, txts_path, img_path, metadata_dir, pdf_files, cpu_count
-    ):
-        self.pdfs_path = pdfs_path
-        self.txts_path = txts_path
-        self.img_path = img_path
-        self.metadata_dir = metadata_dir
+    def __init__(self, data_model: DataModel, pdf_files: list[str], cpu_count: int):
+        self.data_model = data_model
         self.pdf_files = pdf_files
         self.cpu_count = cpu_count
 
     def validate(self) -> None:
-        if not os.path.isdir(self.pdfs_path):
-            raise ValueError(f"PDFs input directory does not exist: {self.pdfs_path}")
+        missing = [f for f in self.pdf_files if not os.path.isfile(f)]
+        if missing:
+            raise ValueError(
+                f"{len(missing)} PDF file(s) not found, e.g.: {missing[0]}"
+            )
 
     def run(self):
-        os.makedirs(self.txts_path, exist_ok=True)
         ctx = get_context("spawn")
         with ctx.Pool(processes=self.cpu_count) as pool:
             results = pool.starmap(
                 _convert_single_pdf,
-                [
-                    (
-                        self.txts_path,
-                        self.img_path,
-                        self.pdfs_path,
-                        self.metadata_dir,
-                        file,
-                    )
-                    for file in self.pdf_files
-                ],
+                [(self.data_model, pdf_file) for pdf_file in self.pdf_files],
             )
         return sum(results)

--- a/govscape/govscape/processing/text_embedding_stage.py
+++ b/govscape/govscape/processing/text_embedding_stage.py
@@ -3,6 +3,7 @@ import os
 
 import numpy as np
 
+from ..config import DataModel
 from ..text_embedding_models import (
     BGE_TextEmbeddingModel,
     BGESmall_TextEmbeddingModel,
@@ -13,25 +14,22 @@ from ..utils import read_txt_file
 from .processing_stage import ProcessingStage
 
 
-def _collect_texts_and_paths(txt_path, embed_path):
-    os.makedirs(embed_path, exist_ok=True)
-
-    txt_subdirs_paths = [
-        txt_subdir.path for txt_subdir in os.scandir(txt_path) if txt_subdir.is_dir()
-    ]
+def _collect_texts_and_paths(data_model: DataModel):
+    os.makedirs(data_model.embedding_directory, exist_ok=True)
 
     text_batch = []
     file_batch = []
-    for txt_subdir_path in txt_subdirs_paths:
-        embed_name = os.path.basename(txt_subdir_path)
-        embedding_dir = os.path.join(embed_path, embed_name)
-        os.makedirs(embedding_dir, exist_ok=True)
+    for txt_subdir in os.scandir(data_model.txt_directory):
+        if not txt_subdir.is_dir():
+            continue
+        digest = txt_subdir.name
+        embed_dir = data_model.embedding_pdf_directory(digest)
+        os.makedirs(embed_dir, exist_ok=True)
 
-        txt_files = os.listdir(txt_subdir_path)
-        for txt_file in txt_files:
-            full_txt_path = os.path.join(txt_subdir_path, txt_file)
+        for txt_file in os.listdir(txt_subdir.path):
+            full_txt_path = os.path.join(txt_subdir.path, txt_file)
             text = read_txt_file(full_txt_path)
-            output_path = os.path.join(embedding_dir, txt_file.replace(".txt", ".npy"))
+            output_path = os.path.join(embed_dir, txt_file.replace(".txt", ".npy"))
             text_batch.append(text)
             file_batch.append(output_path)
 
@@ -51,19 +49,18 @@ def _build_text_model(model_type):
 
 
 class TextEmbeddingStage(ProcessingStage):
-    def __init__(self, txts_path, embeddings_path, model_type):
-        self.txts_path = txts_path
-        self.embeddings_path = embeddings_path
+    def __init__(self, data_model: DataModel, model_type: str):
+        self.data_model = data_model
         self.model = _build_text_model(model_type)
 
     def validate(self) -> None:
-        if not os.path.isdir(self.txts_path):
-            raise ValueError(f"Text input directory does not exist: {self.txts_path}")
+        if not os.path.isdir(self.data_model.txt_directory):
+            raise ValueError(
+                f"Text input directory does not exist: {self.data_model.txt_directory}"
+            )
 
     def run(self):
-        sentences, embed_file_paths = _collect_texts_and_paths(
-            self.txts_path, self.embeddings_path
-        )
+        sentences, embed_file_paths = _collect_texts_and_paths(self.data_model)
         embeddings = self.model.encode_text_batch(sentences)
         logging.info(f"Text embeddings computed. Shape: {embeddings.shape}")
         for embedding, output_path in zip(embeddings, embed_file_paths, strict=False):

--- a/govscape/govscape/server.py
+++ b/govscape/govscape/server.py
@@ -36,16 +36,6 @@ class Server:
 
         # Data model — single source of truth for all directory paths
         self.data_model = config.data_model
-        self.metadata_directory = self.data_model.metadata_directory
-        self.embedding_directory = self.data_model.embedding_directory
-        self.embedding_img_pg_directory = self.data_model.embedding_img_pg_directory
-        self.index_directory = self.data_model.index_directory
-        self.index_img_pg_directory = self.data_model.index_img_pg_directory
-        self.index_keyword_directory = self.data_model.index_keyword_directory
-        self.index_metadata_directory = self.data_model.index_metadata_directory
-        self.image_directory = self.data_model.image_directory
-        self.stats_file = self.data_model.stats_file
-        self.blacklist_file = self.data_model.blacklist_file
         self.vector_index_type = config.vector_index_type
         self.keyword_index_type = config.keyword_index_type
         self.k = config.k
@@ -59,30 +49,38 @@ class Server:
         self.visual_d = config.visual_d
 
         if self.vector_index_type == "Memory":
-            self.text_index = FAISSIndex(self.index_directory)
-            self.visual_index = FAISSIndex(self.index_img_pg_directory)
+            self.text_index = FAISSIndex(self.data_model.index_directory)
+            self.visual_index = FAISSIndex(self.data_model.index_img_pg_directory)
         else:
             raise ValueError(f"Unsupported vector index type: {self.vector_index_type}")
         self.text_index.load_index()
         self.visual_index.load_index()
 
         if self.keyword_index_type == "LanceDB":
-            self.keyword_index: AbstractKeywordIndex = LanceDBKeywordIndex(
-                self.index_keyword_directory
+            self.keyword_index = LanceDBKeywordIndex(
+                self.data_model.index_keyword_directory
             )
         elif self.keyword_index_type == "SQLite":
-            self.keyword_index = SQLiteKeywordIndex(self.index_keyword_directory)
+            self.keyword_index = SQLiteKeywordIndex(
+                self.data_model.index_keyword_directory
+            )
         elif self.keyword_index_type == "Whoosh":
-            self.keyword_index = WhooshKeywordIndex(self.index_keyword_directory)
+            self.keyword_index = WhooshKeywordIndex(
+                self.data_model.index_keyword_directory
+            )
         elif self.keyword_index_type == "Lucene":
-            self.keyword_index = LuceneKeywordIndex(self.index_keyword_directory)
+            self.keyword_index = LuceneKeywordIndex(
+                self.data_model.index_keyword_directory
+            )
         else:
             raise ValueError(
                 f"Unsupported keyword index type: {self.keyword_index_type}"
             )
         self.keyword_index.load_index()
 
-        self.metadata_index = SQLiteMetadataIndex(self.index_metadata_directory)
+        self.metadata_index = SQLiteMetadataIndex(
+            self.data_model.index_metadata_directory
+        )
         self.metadata_index.load_index()
 
         self.blacklist: set[str] = self._load_blacklist()
@@ -118,7 +116,7 @@ class Server:
         self.api = init_api(self.app)
 
     def _load_blacklist(self) -> set[str]:
-        path = self.blacklist_file
+        path = self.data_model.blacklist_file
         if not os.path.exists(path):
             print(f"No blacklist file at {path}; starting with empty blacklist")
             return set()
@@ -216,16 +214,7 @@ class Server:
                     has_more_crawls = len(all_records) > self.max_crawl_instances
                     limited_records = all_records[: self.max_crawl_instances]
                     newest = all_records[0]
-                    jpeg_file = (
-                        self.image_directory
-                        + "/"
-                        + name
-                        + "/"
-                        + name
-                        + "_"
-                        + page_num
-                        + ".jpeg"
-                    )
+                    jpeg_file = self.data_model.img_page_path(name, int(page_num))
                     search_results.append(
                         {
                             "pdf": name,
@@ -312,8 +301,7 @@ class Server:
         sub_domain = newest.get("sub_domain", "")
         page_count = int(newest.get("page_count", 0))
 
-        image_dir = os.path.join(self.image_directory, pdf_id)
-        images = [f"{image_dir}/{pdf_id}_{i}.jpeg" for i in range(page_count)]
+        images = [self.data_model.img_page_path(pdf_id, i) for i in range(page_count)]
 
         crawl_instances = [
             {
@@ -337,7 +325,7 @@ class Server:
         if hasattr(self, "_total_pdfs_cache"):
             return self._total_pdfs_cache
 
-        total_pdfs_path = self.stats_file
+        total_pdfs_path = self.data_model.stats_file
 
         if not total_pdfs_path or not os.path.exists(total_pdfs_path):
             return 0

--- a/govscape/tests/test_embedding_pipeline.py
+++ b/govscape/tests/test_embedding_pipeline.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from govscape.config import DataModel
 from govscape.pdf_processing_pipeline import PDFProcessingPipeline
 from govscape.processing import (
     PageImageEmbeddingStage,
@@ -19,25 +20,21 @@ def sample_pipeline(tmp_path):
     shutil.copytree(source_pdfs, pdf_dir)
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    pipeline = PDFProcessingPipeline(str(pdf_dir), str(data_dir), "Dummy", "Dummy")
-    pdf_files = sorted(f.name for f in pdf_dir.glob("*.pdf"))
+    pipeline = PDFProcessingPipeline(str(data_dir), "Dummy", "Dummy")
+    pdf_files = sorted(str(f) for f in pdf_dir.glob("*.pdf"))
     return pipeline, pdf_files
 
 
 def test_convert_pdf_to_txt_img_and_metadata(sample_pipeline):
     pipeline, pdf_files = sample_pipeline
-    assert "govscape_intro.pdf" in pdf_files
-    _convert_single_pdf(
-        pipeline.txts_path,
-        pipeline.img_path,
-        pipeline.pdfs_path,
-        pipeline.metadata_dir,
-        "govscape_intro.pdf",
-    )
+    pdf_file = next(f for f in pdf_files if Path(f).name == "govscape_intro.pdf")
+    _convert_single_pdf(pipeline.data_model, pdf_file)
 
     pdf_stem = "govscape_intro"
-    text_path = Path(pipeline.txts_path) / pdf_stem / f"{pdf_stem}_0.txt"
-    image_path = Path(pipeline.img_path) / pdf_stem / f"{pdf_stem}_0.jpeg"
+    text_path = Path(pipeline.data_model.txt_directory) / pdf_stem / f"{pdf_stem}_0.txt"
+    image_path = (
+        Path(pipeline.data_model.image_directory) / pdf_stem / f"{pdf_stem}_0.jpeg"
+    )
 
     assert text_path.exists()
     assert image_path.exists()
@@ -49,16 +46,13 @@ def test_convert_pdf_to_txt_img_and_metadata(sample_pipeline):
 def test_convert_pdfs_to_txt_and_img_creates_outputs(sample_pipeline):
     pipeline, pdf_files = sample_pipeline
     PDFExtractionStage(
-        pdfs_path=pipeline.pdfs_path,
-        txts_path=pipeline.txts_path,
-        img_path=pipeline.img_path,
-        metadata_dir=pipeline.metadata_dir,
+        data_model=pipeline.data_model,
         pdf_files=pdf_files,
         cpu_count=pipeline.cpu_count,
     ).run()
 
-    txt_base = Path(pipeline.txts_path)
-    img_base = Path(pipeline.img_path)
+    txt_base = Path(pipeline.data_model.txt_directory)
+    img_base = Path(pipeline.data_model.image_directory)
 
     expected_dirs = {Path(pdf).stem for pdf in pdf_files}
     txt_dirs = {p.name for p in txt_base.iterdir() if p.is_dir()}
@@ -80,23 +74,21 @@ def test_convert_pdfs_to_txt_and_img_creates_outputs(sample_pipeline):
     assert total_img_files > 0
 
 
-def test_pdf_extraction_stage_validate_raises_on_missing_dir(tmp_path):
+def test_pdf_extraction_stage_validate_raises_on_missing_file(tmp_path):
+    data_model = DataModel(str(tmp_path))
     stage = PDFExtractionStage(
-        pdfs_path=str(tmp_path / "nonexistent"),
-        txts_path=str(tmp_path / "txt"),
-        img_path=str(tmp_path / "img"),
-        metadata_dir=str(tmp_path / "metadata"),
-        pdf_files=[],
+        data_model=data_model,
+        pdf_files=[str(tmp_path / "nonexistent.pdf")],
         cpu_count=1,
     )
-    with pytest.raises(ValueError, match="PDFs input directory does not exist"):
+    with pytest.raises(ValueError, match="PDF file"):
         stage.validate()
 
 
 def test_text_embedding_stage_validate_raises_on_missing_dir(tmp_path):
+    data_model = DataModel(str(tmp_path / "nonexistent"))
     stage = TextEmbeddingStage(
-        txts_path=str(tmp_path / "nonexistent"),
-        embeddings_path=str(tmp_path / "embeddings"),
+        data_model=data_model,
         model_type="Dummy",
     )
     with pytest.raises(ValueError, match="Text input directory does not exist"):
@@ -104,9 +96,9 @@ def test_text_embedding_stage_validate_raises_on_missing_dir(tmp_path):
 
 
 def test_page_image_embedding_stage_validate_raises_on_missing_dir(tmp_path):
+    data_model = DataModel(str(tmp_path / "nonexistent"))
     stage = PageImageEmbeddingStage(
-        img_path=str(tmp_path / "nonexistent"),
-        embeddings_img_path=str(tmp_path / "embeddings_img"),
+        data_model=data_model,
         model_type="Dummy",
         cpu_count=1,
     )
@@ -114,37 +106,33 @@ def test_page_image_embedding_stage_validate_raises_on_missing_dir(tmp_path):
         stage.validate()
 
 
-def test_pdf_extraction_stage_validate_passes_with_existing_dir(tmp_path):
-    pdfs_dir = tmp_path / "pdfs"
-    pdfs_dir.mkdir()
+def test_pdf_extraction_stage_validate_passes_with_existing_files(tmp_path):
+    pdf_file = tmp_path / "test.pdf"
+    pdf_file.touch()
+    data_model = DataModel(str(tmp_path))
     stage = PDFExtractionStage(
-        pdfs_path=str(pdfs_dir),
-        txts_path=str(tmp_path / "txt"),
-        img_path=str(tmp_path / "img"),
-        metadata_dir=str(tmp_path / "metadata"),
-        pdf_files=[],
+        data_model=data_model,
+        pdf_files=[str(pdf_file)],
         cpu_count=1,
     )
     stage.validate()  # should not raise
 
 
 def test_text_embedding_stage_validate_passes_with_existing_dir(tmp_path):
-    txts_dir = tmp_path / "txt"
-    txts_dir.mkdir()
+    data_model = DataModel(str(tmp_path))
+    (tmp_path / "txt").mkdir()
     stage = TextEmbeddingStage(
-        txts_path=str(txts_dir),
-        embeddings_path=str(tmp_path / "embeddings"),
+        data_model=data_model,
         model_type="Dummy",
     )
     stage.validate()  # should not raise
 
 
 def test_page_image_embedding_stage_validate_passes_with_existing_dir(tmp_path):
-    img_dir = tmp_path / "img"
-    img_dir.mkdir()
+    data_model = DataModel(str(tmp_path))
+    (tmp_path / "img").mkdir()
     stage = PageImageEmbeddingStage(
-        img_path=str(img_dir),
-        embeddings_img_path=str(tmp_path / "embeddings_img"),
+        data_model=data_model,
         model_type="Dummy",
         cpu_count=1,
     )
@@ -165,8 +153,8 @@ def test_process_pdfs_text_only(sample_pipeline):
     assert len(timings) == 3
     assert all(isinstance(value, float) for value in timings)
 
-    txt_base = Path(pipeline.txts_path)
-    img_base = Path(pipeline.img_path)
+    txt_base = Path(pipeline.data_model.txt_directory)
+    img_base = Path(pipeline.data_model.image_directory)
 
     for pdf_file in pdf_files:
         stem = Path(pdf_file).stem

--- a/govscape/tests/test_serving.py
+++ b/govscape/tests/test_serving.py
@@ -142,8 +142,8 @@ def test_server_initialization(server_fixture):
     assert Path(data_model.index_img_pg_directory).exists()
     assert Path(data_model.image_directory).exists()
 
-    assert server.index_directory == data_model.index_directory
-    assert server.image_directory == data_model.image_directory
+    assert server.data_model.index_directory == data_model.index_directory
+    assert server.data_model.image_directory == data_model.image_directory
     assert server.config.k == 3
 
 

--- a/scripts/pipeline/run_embedding_pipeline.py
+++ b/scripts/pipeline/run_embedding_pipeline.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
         )
 
         processor = gs.PDFProcessingPipeline(
-            LOCAL_PDF_DIR, LOCAL_DATA_DIR, args.text_model_type, args.visual_model_type
+            LOCAL_DATA_DIR, args.text_model_type, args.visual_model_type
         )
 
         overall_start_time = time.time()

--- a/scripts/pipeline/run_embedding_pipeline.py
+++ b/scripts/pipeline/run_embedding_pipeline.py
@@ -25,20 +25,13 @@ def process_pdfs(
     do_img_embedding,
     do_metadata_collection,
     pipeline_times,
-    data_dir_backend,
     data_loader,
-    local_data_dir,
+    local_dm,
+    remote_dm,
 ):
     print("Do_Text_embedding: ", do_text_embedding)
     print("Do_Img_embedding: ", do_img_embedding)
     print("Do_Metadata_collection: ", do_metadata_collection)
-
-    dm = DataModel(local_data_dir)
-    txt_directory = dm.txt_directory
-    image_directory = dm.image_directory
-    embeddings_directory = dm.embedding_directory
-    embeddings_img_pg_directory = dm.embedding_img_pg_directory
-    metadata_dir = dm.metadata_directory
 
     # PROCESS PDFS HERE
     pdf_to_txt_img_time, text_embed_time, img_embed_time = processor.process_pdfs(
@@ -50,36 +43,37 @@ def process_pdfs(
 
     time1 = time.time()
     # UPLOADING EMBEDDINGS, TXTS, IMAGES TO S3 HERE
-    if do_text_embedding or do_img_embedding:
+    if do_text_embedding or do_img_embedding or do_metadata_collection:
         data_loader.upload_directory(
-            txt_directory, os.path.join(data_dir_backend, "txt"), compress=True
+            local_dm.txt_directory, remote_dm.txt_directory, compress=True
         )
         print("finished uploading txt")
 
         data_loader.upload_directory(
-            image_directory, os.path.join(data_dir_backend, "img"), compress=False
+            local_dm.image_directory, remote_dm.image_directory, compress=False
         )
         print("finished uploading img")
-    if do_text_embedding:
+
         data_loader.upload_directory(
-            embeddings_directory,
-            os.path.join(data_dir_backend, "embeddings"),
-            compress=True,
-        )
-        print("finished uploading embeddings")
-    if do_img_embedding:
-        data_loader.upload_directory(
-            embeddings_img_pg_directory,
-            os.path.join(data_dir_backend, "embeddings_img_pg"),
-            compress=True,
-        )
-        print("finished uploading embed img pg")
-    if do_metadata_collection:
-        data_loader.upload_directory(
-            metadata_dir, os.path.join(data_dir_backend, "metadata"), compress=True
+            local_dm.metadata_directory, remote_dm.metadata_directory, compress=True
         )
         print("finished uploading metadata")
 
+    if do_text_embedding:
+        data_loader.upload_directory(
+            local_dm.embedding_directory,
+            remote_dm.embedding_directory,
+            compress=True,
+        )
+        print("finished uploading embeddings")
+
+    if do_img_embedding:
+        data_loader.upload_directory(
+            local_dm.embedding_img_pg_directory,
+            remote_dm.embedding_img_pg_directory,
+            compress=True,
+        )
+        print("finished uploading embed img pg")
     time2 = time.time()
 
     pipeline_times["upload"] += time2 - time1
@@ -89,206 +83,186 @@ def process_pdfs(
     print("pipeline times: ", pipeline_times)
 
 
-if __name__ == "__main__":
-    # overall method that gets the files in batches and runs them through the
-    # pipeline
-    def main():
-        # FIELDS TO SET --------------------------------------------------------
-        parser = base_argument_parser(description="S3 EC2 Embedding Pipeline")
-        parser.add_argument(
-            "--text_model_type",
-            type=str,
-            help="The model type to use for text embedding",
-            default="ST",
-        )
-        parser.add_argument(
-            "--visual_model_type",
-            type=str,
-            help="The model type to use for visual embedding",
-            default="CLIP",
-        )
-        parser.add_argument(
-            "--num_servers",
-            type=int,
-            help="The number of servers to use for embedding",
-            default=1,
-        )
-        parser.add_argument(
-            "--server_id", type=int, help="The ID of the current server", default=0
-        )
-        parser.add_argument(
-            "--do_text_embedding",
-            type=str2bool,
-            help="Whether to do text embedding",
-            default=True,
-        )
-        parser.add_argument(
-            "--do_img_embedding",
-            type=str2bool,
-            help="Whether to do image embedding",
-            default=True,
-        )
-        parser.add_argument(
-            "--do_metadata_collection",
-            type=str2bool,
-            help="Whether to do metadata collection",
-            default=True,
-        )
-        parser.add_argument("--pdf_dir", type=str, help="Directory containing PDFs")
-        args = parser.parse_args()
-        NUM_PAGES_TO_PROCESS = args.num_pages_to_process
-        BATCH_SIZE = args.batch_size
+def cleanup(local_dm, local_pdf_dir):
+    if os.path.exists(local_dm.data_dir):
+        if os.path.exists(local_dm.txt_directory):
+            shutil.rmtree(local_dm.txt_directory)
+        if os.path.exists(local_dm.image_directory):
+            shutil.rmtree(local_dm.image_directory)
+        if os.path.exists(local_dm.embedding_directory):
+            shutil.rmtree(local_dm.embedding_directory)
+        if os.path.exists(local_dm.embedding_img_pg_directory):
+            shutil.rmtree(local_dm.embedding_img_pg_directory)
+        if os.path.exists(local_dm.metadata_directory):
+            shutil.rmtree(local_dm.metadata_directory)
+        os.makedirs(local_dm.data_dir, exist_ok=True)
 
-        # ---------------------------------------------------------------------------
-        BUCKET_NAME = args.bucket_name
-        REMOTE_PDF_DIR = args.pdf_dir  # e.g. "archive/2020/PDFs/"
-        REMOTE_DATA_DIR = args.remote_data_dir  # e.g. "prod-serving"
-        PROJECT_ROOT = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "../../")
-        )  # e.g. "govscape"
-        LOCAL_DATA_DIR = os.path.join(
-            PROJECT_ROOT, "data", "prod"
-        )  # "govscape/data/prod"
-        local_dm = DataModel(LOCAL_DATA_DIR)
-        LOCAL_PDF_DIR = os.path.join(
-            LOCAL_DATA_DIR, "PDFs"
-        )  # e.g. "govscape/data/prod/PDFs"
-        LOCAL_TXT_DIR = local_dm.txt_directory
-        LOCAL_IMG_DIR = local_dm.image_directory
-        LOCAL_EMBEDDINGS_DIR = local_dm.embedding_directory
-        LOCAL_EMBEDDINGS_IMG_PG_DIR = local_dm.embedding_img_pg_directory
-        LOCAL_METADATA_DIR = local_dm.metadata_directory
-        remote_dm = DataModel(REMOTE_DATA_DIR)
-        LOCAL_CHECKPOINT_PATH = os.path.join(
-            local_dm.checkpoints_directory,
-            f"checkpoint_embedding_pipeline_{args.server_id}.json",
-        )
-        REMOTE_CHECKPOINT_PATH = os.path.join(
-            remote_dm.checkpoints_directory,
-            f"checkpoint_embedding_pipeline_{args.server_id}.json",
-        )
-        LOCAL_PERF_PATH = os.path.join(
-            local_dm.performance_directory,
-            f"performance_{args.server_id}.json",
-        )
-        REMOTE_PERF_PATH = os.path.join(
-            remote_dm.performance_directory,
-            f"performance_{args.server_id}.json",
-        )
+    if os.path.exists(local_pdf_dir):
+        shutil.rmtree(local_pdf_dir)
+        os.makedirs(local_pdf_dir, exist_ok=True)
 
-        os.makedirs(LOCAL_DATA_DIR, exist_ok=True)
-        os.makedirs(LOCAL_PDF_DIR, exist_ok=True)
-        os.makedirs(local_dm.checkpoints_directory, exist_ok=True)
-        os.makedirs(local_dm.performance_directory, exist_ok=True)
 
-        # ---------------------------------------------------------------------------
-        pipeline_times = {
-            "list": 0,
-            "download": 0,
-            "pdf_to_txt_img_time": 0,
-            "text_embed_time": 0,
-            "img_embed_time": 0,
-            "upload": 0,
-            "pdfs_processed": 0,
-        }
-        # to keep track of the time it takes for each step in the pipeline
+# overall method that gets the files in batches and runs them through the
+# pipeline
+def main():
+    # FIELDS TO SET --------------------------------------------------------
+    parser = base_argument_parser(description="S3 EC2 Embedding Pipeline")
+    parser.add_argument(
+        "--text_model_type",
+        type=str,
+        help="The model type to use for text embedding",
+        default="ST",
+    )
+    parser.add_argument(
+        "--visual_model_type",
+        type=str,
+        help="The model type to use for visual embedding",
+        default="CLIP",
+    )
+    parser.add_argument(
+        "--num_servers",
+        type=int,
+        help="The number of servers to use for embedding",
+        default=1,
+    )
+    parser.add_argument(
+        "--server_id", type=int, help="The ID of the current server", default=0
+    )
+    parser.add_argument(
+        "--do_text_embedding",
+        type=str2bool,
+        help="Whether to do text embedding",
+        default=True,
+    )
+    parser.add_argument(
+        "--do_img_embedding",
+        type=str2bool,
+        help="Whether to do image embedding",
+        default=True,
+    )
+    parser.add_argument(
+        "--do_metadata_collection",
+        type=str2bool,
+        help="Whether to do metadata collection",
+        default=True,
+    )
+    parser.add_argument("--pdf_dir", type=str, help="Directory containing PDFs")
+    args = parser.parse_args()
 
-        data_loader = build_data_loader(
-            args.backend,
-            BUCKET_NAME,
-            local_base_dir=args.local_base_dir,
+    # ---------------------------------------------------------------------------
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+    local_dm = DataModel(os.path.join(project_root, "data", "prod"))
+    remote_dm = DataModel(args.remote_data_dir)
+    local_pdf_dir = os.path.join(local_dm.data_dir, "PDFs")
+    local_checkpoint_path = local_dm.checkpoint_file_path(
+        f"embedding_pipeline_{args.server_id}"
+    )
+    remote_checkpoint_path = remote_dm.checkpoint_file_path(
+        f"embedding_pipeline_{args.server_id}"
+    )
+    local_perf_path = local_dm.performance_file_path(
+        f"embedding_pipeline_{args.server_id}"
+    )
+    remote_perf_path = remote_dm.performance_file_path(
+        f"embedding_pipeline_{args.server_id}"
+    )
+
+    os.makedirs(local_dm.data_dir, exist_ok=True)
+    os.makedirs(local_pdf_dir, exist_ok=True)
+    os.makedirs(local_dm.checkpoints_directory, exist_ok=True)
+    os.makedirs(local_dm.performance_directory, exist_ok=True)
+
+    # ---------------------------------------------------------------------------
+    pipeline_times = {
+        "list": 0,
+        "download": 0,
+        "pdf_to_txt_img_time": 0,
+        "text_embed_time": 0,
+        "img_embed_time": 0,
+        "upload": 0,
+        "pdfs_processed": 0,
+    }
+    # to keep track of the time it takes for each step in the pipeline
+
+    data_loader = build_data_loader(
+        args.backend,
+        args.bucket_name,
+        local_base_dir=args.local_base_dir,
+    )
+    remote_pdf_iter = RemoteDirectoryIterator(
+        data_loader,
+        args.pdf_dir,
+        remote_checkpoint_path=remote_checkpoint_path,
+        local_checkpoint_path=local_checkpoint_path,
+        local_dir=local_pdf_dir,
+    )
+
+    processor = gs.PDFProcessingPipeline(
+        local_dm.data_dir, args.text_model_type, args.visual_model_type
+    )
+
+    overall_start_time = time.time()
+
+    max_files_to_process = args.num_pages_to_process * 1000
+    files_processed = 0
+    while files_processed < max_files_to_process:
+        print("-" * 93)
+        print("FILES PROCESSED: ", files_processed)
+        print("-" * 93)
+        time_download = time.time()
+        os.makedirs(local_pdf_dir, exist_ok=True)
+        batch_limit = min(args.batch_size, max_files_to_process - files_processed)
+        local_batch = remote_pdf_iter.download_batch(
+            max_keys=batch_limit,
+            filter_fn=lambda key: (
+                key.endswith(".pdf")
+                and (hash(key) % args.num_servers) == args.server_id
+            ),
         )
-        remote_pdf_iter = RemoteDirectoryIterator(
+        pipeline_times["download"] += time.time() - time_download
+        if not local_batch:
+            break
+        print("len(local_batch) = ", len(local_batch))
+
+        process_pdfs(
+            local_batch,
+            processor,
+            args.do_text_embedding,
+            args.do_img_embedding,
+            args.do_metadata_collection,
+            pipeline_times,
             data_loader,
-            REMOTE_PDF_DIR,
-            remote_checkpoint_path=REMOTE_CHECKPOINT_PATH,
-            local_checkpoint_path=LOCAL_CHECKPOINT_PATH,
-            local_dir=LOCAL_PDF_DIR,
+            local_dm,
+            remote_dm,
         )
 
-        processor = gs.PDFProcessingPipeline(
-            LOCAL_DATA_DIR, args.text_model_type, args.visual_model_type
-        )
+        remote_pdf_iter.save_checkpoint()
+        files_processed += len(local_batch)
 
-        overall_start_time = time.time()
+        # Delete local data to free up space for the next batch
+        cleanup(local_dm, local_pdf_dir)
 
-        max_files_to_process = NUM_PAGES_TO_PROCESS * 1000
-        files_processed = 0
-        while files_processed < max_files_to_process:
-            print("-" * 93)
-            print("FILES PROCESSED: ", files_processed)
-            print("-" * 93)
-            time_download = time.time()
-            os.makedirs(LOCAL_PDF_DIR, exist_ok=True)
-            batch_limit = min(BATCH_SIZE, max_files_to_process - files_processed)
-            local_batch = remote_pdf_iter.download_batch(
-                max_keys=batch_limit,
-                filter_fn=lambda key: (
-                    key.endswith(".pdf")
-                    and (hash(key) % args.num_servers) == args.server_id
-                ),
-            )
-            pipeline_times["download"] += time.time() - time_download
-            if not local_batch:
-                break
-            print("len(local_batch) = ", len(local_batch))
+        # Write pipeline_times to a JSON file
+        with open(local_perf_path, "w") as f:
+            json.dump(pipeline_times, f, indent=2)
 
-            process_pdfs(
-                local_batch,
-                processor,
-                args.do_text_embedding,
-                args.do_img_embedding,
-                args.do_metadata_collection,
-                pipeline_times,
-                REMOTE_DATA_DIR,
-                data_loader,
-                LOCAL_DATA_DIR,
-            )
+        # Upload the performance JSON to S3
+        data_loader.upload_file(local_perf_path, remote_perf_path)
 
-            remote_pdf_iter.save_checkpoint()
-            files_processed += len(local_batch)
+    # After all batches are processed, clean up the directories
+    if os.path.exists(local_dm.data_dir):
+        shutil.rmtree(local_dm.data_dir)
+        os.makedirs(local_dm.data_dir, exist_ok=True)
 
-            if os.path.exists(LOCAL_DATA_DIR):
-                if args.do_text_embedding or args.do_img_embedding:
-                    if os.path.exists(LOCAL_TXT_DIR):
-                        shutil.rmtree(LOCAL_TXT_DIR)
-                    if os.path.exists(LOCAL_IMG_DIR):
-                        shutil.rmtree(LOCAL_IMG_DIR)
-                if args.do_text_embedding and os.path.exists(LOCAL_EMBEDDINGS_DIR):
-                    shutil.rmtree(LOCAL_EMBEDDINGS_DIR)
-                if args.do_img_embedding and os.path.exists(
-                    LOCAL_EMBEDDINGS_IMG_PG_DIR
-                ):
-                    shutil.rmtree(LOCAL_EMBEDDINGS_IMG_PG_DIR)
-                if args.do_metadata_collection and os.path.exists(LOCAL_METADATA_DIR):
-                    shutil.rmtree(LOCAL_METADATA_DIR)
-                os.makedirs(LOCAL_DATA_DIR, exist_ok=True)
+    overall_end_time = time.time()
+    print("TOTAL TIME TO LOAD IS ", (overall_end_time - overall_start_time))
+    print("TOTAL TIME list pdfs:", pipeline_times["list"])
+    print("TOTAL TIME download pdfs:", pipeline_times["download"])
+    print("TOTAL TIME pdf -> txt and img time:", pipeline_times["pdf_to_txt_img_time"])
+    print("TOTAL TIME txt -> embed time:", pipeline_times["text_embed_time"])
+    print("TOTAL TIME img -> embed time:", pipeline_times["img_embed_time"])
+    print("TOTAL TIME uploading data:", pipeline_times["upload"])
 
-            if os.path.exists(LOCAL_PDF_DIR):
-                shutil.rmtree(LOCAL_PDF_DIR)
-                os.makedirs(LOCAL_PDF_DIR, exist_ok=True)
 
-            # Write pipeline_times to a JSON file
-            with open(LOCAL_PERF_PATH, "w") as f:
-                json.dump(pipeline_times, f, indent=2)
-
-            # Upload the performance JSON to S3
-            data_loader.upload_file(LOCAL_PERF_PATH, REMOTE_PERF_PATH)
-
-        # After all batches are processed, clean up the directories
-        if os.path.exists(LOCAL_DATA_DIR):
-            shutil.rmtree(LOCAL_DATA_DIR)
-            os.makedirs(LOCAL_DATA_DIR, exist_ok=True)
-
-        overall_end_time = time.time()
-        print("TOTAL TIME TO LOAD IS ", (overall_end_time - overall_start_time))
-        print("TOTAL TIME list pdfs:", pipeline_times["list"])
-        print("TOTAL TIME download pdfs:", pipeline_times["download"])
-        print(
-            "TOTAL TIME pdf -> txt and img time:", pipeline_times["pdf_to_txt_img_time"]
-        )
-        print("TOTAL TIME txt -> embed time:", pipeline_times["text_embed_time"])
-        print("TOTAL TIME img -> embed time:", pipeline_times["img_embed_time"])
-        print("TOTAL TIME uploading data:", pipeline_times["upload"])
-
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
There were still many places in the code doing manual os.path manipulation to create pdf and page-level file paths. This should also be centralized and handled by the DataModel class instead. 

This PR makes this change by adding pdf and page-level functions to data model then modifying various classes/functions to be passed a data model rather than a class.