### PR TITLE
Slightly Improved PDF Titles

### DIFF
--- a/DATA_MODEL.md
+++ b/DATA_MODEL.md
@@ -28,7 +28,6 @@ The pdf_metadata.parquet file has the following columns:
 * length : The number of bytes corresponding to the pdf's warc record.
 
 The metadata.db database has a table with the columns:
-* id INTEGER PRIMARY KEY AUTOINCREMENT,
 * url TEXT,
 * crawl_date TEXT,
 * digest TEXT,

--- a/DATA_MODEL.md
+++ b/DATA_MODEL.md
@@ -31,7 +31,8 @@ The metadata.db database has a table with the columns:
 * id INTEGER PRIMARY KEY AUTOINCREMENT,
 * url TEXT,
 * crawl_date TEXT,
-* pdf_name TEXT,
+* digest TEXT,
+* pretty_name TEXT,
 * sub_domain TEXT,
 * page_count INTEGER
 

--- a/govscape/benchmarks/metadata_index_benchmark.py
+++ b/govscape/benchmarks/metadata_index_benchmark.py
@@ -82,7 +82,6 @@ def generate_metadata(
                 "pdf_name": pdf_name,
                 "sub_domain": sub_domain,
                 "page_count": rng.randint(1, 200),
-                "s3_url": f"s3://govscape/{sub_domain}/{pdf_name}",
             }
         )
     return records

--- a/govscape/benchmarks/metadata_index_benchmark.py
+++ b/govscape/benchmarks/metadata_index_benchmark.py
@@ -79,7 +79,8 @@ def generate_metadata(
             {
                 "crawl_url": f"https://{sub_domain}/reports/{pdf_name}",
                 "crawl_date": crawl_date,
-                "pdf_name": pdf_name,
+                "digest": pdf_name,
+                "pretty_name": f"Document {idx}",
                 "sub_domain": sub_domain,
                 "page_count": rng.randint(1, 200),
             }

--- a/govscape/govscape/indexing/metadata.py
+++ b/govscape/govscape/indexing/metadata.py
@@ -18,14 +18,14 @@ class AbstractMetadataIndex(ABC):
         """
         Instantiate the index in the directory 'self.index_metadata_directory'
         which should store the following data:
-        url, crawl_date, pdf_name, sub_domain
+        url, crawl_date, digest, sub_domain
         """
 
     @abstractmethod
     def add_batch(self, metadata_dicts):
         """
         Add a batch of metadata dictionaries to the index which each
-        contain url, crawl_date, pdf_name, and sub_domain.
+        contain url, crawl_date, digest, and sub_domain.
         """
 
     @abstractmethod
@@ -41,9 +41,9 @@ class AbstractMetadataIndex(ABC):
         """
 
     @abstractmethod
-    def search(self, pdf_names, predicates):
+    def search(self, digests, predicates):
         """
-        Return the metadata for the pdfs in 'pdf_names' that satisfy all 'predicates'.
+        Return the metadata for the pdfs in 'digests' that satisfy all 'predicates'.
         """
 
     @abstractmethod
@@ -78,10 +78,10 @@ class SQLiteMetadataIndex(AbstractMetadataIndex):
             CREATE TABLE IF NOT EXISTS metadata (
                 crawl_url TEXT,
                 crawl_date TEXT,
-                pdf_name TEXT,
+                digest TEXT,
+                pretty_name TEXT,
                 sub_domain TEXT,
-                page_count INTEGER,
-                s3_url TEXT
+                page_count INTEGER
             );
         """)
         self.conn.commit()
@@ -90,21 +90,21 @@ class SQLiteMetadataIndex(AbstractMetadataIndex):
         if self.conn is None:
             self.conn = sqlite3.connect(self.db_path)
             self.cursor = self.conn.cursor()
-        self.cursor.execute("DROP INDEX IF EXISTS idx_pdf_name_sub_domain_crawl_date;")
+        self.cursor.execute("DROP INDEX IF EXISTS idx_digest_sub_domain_crawl_date;")
         to_insert = [
             (
                 md.get("crawl_url", ""),
                 self._normalize_crawl_date(md.get("crawl_date", "")),
-                md.get("pdf_name", ""),
+                md.get("digest", ""),
+                md.get("pretty_name", ""),
                 md.get("sub_domain", ""),
                 md.get("page_count", 0),
-                md.get("s3_url", ""),
             )
             for md in metadata_dicts
         ]
         self.cursor.executemany(
             "INSERT INTO metadata ("
-            "crawl_url, crawl_date, pdf_name, sub_domain, page_count, s3_url"
+            "crawl_url, crawl_date, digest, pretty_name, sub_domain, page_count"
             ") VALUES (?, ?, ?, ?, ?, ?)",
             to_insert,
         )
@@ -122,28 +122,28 @@ class SQLiteMetadataIndex(AbstractMetadataIndex):
         self.cursor = self.conn.cursor()
 
         # Set of indexes to speed up:
-        # 1. pdf_name
-        # 2. pdf_name + crawl_date # Adding a separate index here does not help
-        # 3. pdf_name + sub_domain
-        # 4. pdf_name + sub_domain + crawl_date
+        # 1. digest
+        # 2. digest + crawl_date # Adding a separate index here does not help
+        # 3. digest + sub_domain
+        # 4. digest + sub_domain + crawl_date
 
         self.cursor.execute("""
-            CREATE INDEX IF NOT EXISTS idx_pdf_name_sub_domain_crawl_date
-            ON metadata (pdf_name, sub_domain, crawl_date);""")
+            CREATE INDEX IF NOT EXISTS idx_digest_sub_domain_crawl_date
+            ON metadata (digest, sub_domain, crawl_date);""")
 
         self.cursor.execute("""PRAGMA journal_mode = WAL;""")
         self.cursor.execute("""PRAGMA optimize;""")
 
         self.conn.commit()
 
-    def search(self, pdf_names, predicates: list[Predicate] | None = None):
+    def search(self, digests, predicates: list[Predicate] | None = None):
         cursor = self.conn.cursor()
-        placeholders = ",".join(["?"] * len(pdf_names))
+        placeholders = ",".join(["?"] * len(digests))
         query = (
-            "SELECT crawl_url, crawl_date, pdf_name, sub_domain, s3_url, page_count "
-            f"FROM metadata WHERE pdf_name IN ({placeholders})"
+            "SELECT crawl_url, crawl_date, digest, pretty_name, sub_domain, page_count "
+            f"FROM metadata WHERE digest IN ({placeholders})"
         )
-        params = list(pdf_names)
+        params = list(digests)
         if predicates:
             for predicate in predicates:
                 if isinstance(predicate, EqualityPredicate):
@@ -160,18 +160,19 @@ class SQLiteMetadataIndex(AbstractMetadataIndex):
         rows = cursor.fetchall()
         metadata = {}
         for row in rows:
-            pdf_name = row[2]
+            digest = row[2]
             row_dict = {
                 "crawl_url": row[0],
                 "crawl_date": row[1],
-                "pdf_name": row[2],
-                "sub_domain": row[3],
+                "digest": row[2],
+                "pretty_name": row[3],
+                "sub_domain": row[4],
                 "page_count": row[5],
             }
-            if pdf_name not in metadata:
-                metadata[pdf_name] = [row_dict]
+            if digest not in metadata:
+                metadata[digest] = [row_dict]
             else:
-                metadata[pdf_name].append(row_dict)
+                metadata[digest].append(row_dict)
         # Return as a dict with lists of dicts representing every time the pdf was
         # crawled.
         return metadata
@@ -200,10 +201,10 @@ class DuckDBMetadataIndex(AbstractMetadataIndex):
             CREATE TABLE IF NOT EXISTS metadata (
                 crawl_url TEXT,
                 crawl_date TEXT,
-                pdf_name TEXT,
+                digest TEXT,
+                pretty_name TEXT,
                 sub_domain TEXT,
-                page_count INTEGER,
-                s3_url TEXT
+                page_count INTEGER
             );
         """)
 
@@ -218,12 +219,12 @@ class DuckDBMetadataIndex(AbstractMetadataIndex):
                     self._normalize_crawl_date(md.get("crawl_date", ""))
                     for md in metadata_dicts
                 ],
-                "pdf_name": [md.get("pdf_name", "") for md in metadata_dicts],
+                "digest": [md.get("digest", "") for md in metadata_dicts],
+                "pretty_name": [md.get("pretty_name", "") for md in metadata_dicts],
                 "sub_domain": [md.get("sub_domain", "") for md in metadata_dicts],
                 "page_count": pa.array(
                     [md.get("page_count", 0) for md in metadata_dicts], type=pa.int32()
                 ),
-                "s3_url": [md.get("s3_url", "") for md in metadata_dicts],
             }
         )
         self.conn.register("_batch", arrow_table)
@@ -239,18 +240,18 @@ class DuckDBMetadataIndex(AbstractMetadataIndex):
     def save_index(self):
         self._connect()
         self.conn.execute("""
-            CREATE INDEX IF NOT EXISTS idx_pdf_name ON metadata (pdf_name);
+            CREATE INDEX IF NOT EXISTS idx_digest ON metadata (digest);
                             """)
         self.conn.checkpoint()
 
-    def search(self, pdf_names: list[str], predicates: list[Predicate] | None = None):
+    def search(self, digests: list[str], predicates: list[Predicate] | None = None):
         self._connect()
-        placeholders = ", ".join(["?"] * len(pdf_names))
+        placeholders = ", ".join(["?"] * len(digests))
         query = (
-            "SELECT crawl_url, crawl_date, pdf_name, sub_domain, s3_url, page_count "
-            f"FROM metadata WHERE pdf_name IN ({placeholders})"
+            "SELECT crawl_url, crawl_date, digest, pretty_name, sub_domain, page_count "
+            f"FROM metadata WHERE digest IN ({placeholders})"
         )
-        params: list = list(pdf_names)
+        params: list = list(digests)
         if predicates:
             for predicate in predicates:
                 if isinstance(predicate, EqualityPredicate):
@@ -266,18 +267,19 @@ class DuckDBMetadataIndex(AbstractMetadataIndex):
         rows = self.conn.execute(query, params).fetchall()
         metadata = {}
         for row in rows:
-            pdf_name = row[2]
+            digest = row[2]
             row_dict = {
                 "crawl_url": row[0],
                 "crawl_date": row[1],
-                "pdf_name": row[2],
-                "sub_domain": row[3],
+                "digest": row[2],
+                "pretty_name": row[3],
+                "sub_domain": row[4],
                 "page_count": row[5],
             }
-            if pdf_name not in metadata:
-                metadata[pdf_name] = [row_dict]
+            if digest not in metadata:
+                metadata[digest] = [row_dict]
             else:
-                metadata[pdf_name].append(row_dict)
+                metadata[digest].append(row_dict)
         # Return as a dict with lists of dicts representing every time the pdf was
         # crawled.
         return metadata

--- a/govscape/govscape/processing/pdf_extraction_stage.py
+++ b/govscape/govscape/processing/pdf_extraction_stage.py
@@ -15,8 +15,7 @@ def _convert_single_pdf(data_model, pdf_file):
     try:
         pdf = pypdfium2.PdfDocument(pdf_file)
         num_pages = len(pdf)
-        pretty_name = pdf.get_metadata_value("Title")
-
+        pretty_name = pdf.get_metadata_value("Title").strip()
         json_data = {}
         creation_date = pdf.get_metadata_value("CreationDate")
         if len(pretty_name) == 0:

--- a/govscape/govscape/processing/pdf_extraction_stage.py
+++ b/govscape/govscape/processing/pdf_extraction_stage.py
@@ -15,16 +15,17 @@ def _convert_single_pdf(data_model, pdf_file):
     try:
         pdf = pypdfium2.PdfDocument(pdf_file)
         num_pages = len(pdf)
-        gov_name = pdf.get_metadata_value("Title")
+        pretty_name = pdf.get_metadata_value("Title")
 
         json_data = {}
-        timestamp = pdf.get_metadata_value("CreationDate")
-        if len(gov_name) == 0:
-            gov_name = "Unknown"
-        if len(timestamp) == 0:
-            timestamp = "Unknown"
-        json_data["gov_name"] = gov_name
-        json_data["timestamp"] = timestamp
+        creation_date = pdf.get_metadata_value("CreationDate")
+        if len(pretty_name) == 0:
+            pretty_name = "Unknown"
+        if len(creation_date) == 0:
+            creation_date = "Unknown"
+        json_data["pretty_name"] = pretty_name
+        json_data["digest"] = pdf_name
+        json_data["creation_date"] = creation_date
         json_data["num_pages"] = num_pages
         os.makedirs(data_model.metadata_pdf_directory(pdf_name), exist_ok=True)
         with open(data_model.metadata_file_path(pdf_name), "w") as json_file:

--- a/govscape/govscape/processing/pdf_extraction_stage.py
+++ b/govscape/govscape/processing/pdf_extraction_stage.py
@@ -20,7 +20,7 @@ def _convert_single_pdf(data_model, pdf_file):
         json_data = {}
         creation_date = pdf.get_metadata_value("CreationDate")
         if len(pretty_name) == 0:
-            pretty_name = "Unknown"
+            pretty_name = ""
         if len(creation_date) == 0:
             creation_date = "Unknown"
         json_data["pretty_name"] = pretty_name

--- a/govscape/govscape/server.py
+++ b/govscape/govscape/server.py
@@ -218,6 +218,7 @@ class Server:
                     search_results.append(
                         {
                             "pdf": name,
+                            "pretty_name": newest.get("pretty_name", ""),
                             "page": page_num,
                             "distance": float(distance),
                             "jpeg": jpeg_file,

--- a/govscape/tests/test_metadata_indexes.py
+++ b/govscape/tests/test_metadata_indexes.py
@@ -11,43 +11,43 @@ _RECORDS = [
     {
         "crawl_url": "https://epa.gov/reports/air_quality.pdf",
         "crawl_date": "20220315",
-        "pdf_name": "air_quality.pdf",
+        "digest": "air_quality.pdf",
+        "pretty_name": "Air Quality Report",
         "sub_domain": "epa.gov",
         "page_count": 42,
-        "s3_url": "s3://govscape/epa.gov/air_quality.pdf",
     },
     {
         "crawl_url": "https://energy.gov/reports/solar_grid.pdf",
         "crawl_date": "20230601",
-        "pdf_name": "solar_grid.pdf",
+        "digest": "solar_grid.pdf",
+        "pretty_name": "Solar Grid Analysis",
         "sub_domain": "energy.gov",
         "page_count": 18,
-        "s3_url": "s3://govscape/energy.gov/solar_grid.pdf",
     },
     {
         "crawl_url": "https://epa.gov/reports/water_quality.pdf",
         "crawl_date": "20240101",
-        "pdf_name": "water_quality.pdf",
+        "digest": "water_quality.pdf",
+        "pretty_name": "Water Quality Study",
         "sub_domain": "epa.gov",
         "page_count": 55,
-        "s3_url": "s3://govscape/epa.gov/water_quality.pdf",
     },
     {
         "crawl_url": "https://nasa.gov/reports/climate_data.pdf",
         "crawl_date": "20210820",
-        "pdf_name": "climate_data.pdf",
+        "digest": "climate_data.pdf",
+        "pretty_name": "Climate Data Summary",
         "sub_domain": "nasa.gov",
         "page_count": 77,
-        "s3_url": "s3://govscape/nasa.gov/climate_data.pdf",
     },
-    # Same pdf_name crawled twice from the same domain on different dates.
+    # Same digest crawled twice from the same domain on different dates.
     {
         "crawl_url": "https://epa.gov/reports/air_quality.pdf",
         "crawl_date": "20230101",
-        "pdf_name": "air_quality.pdf",
+        "digest": "air_quality.pdf",
+        "pretty_name": "Air Quality Report",
         "sub_domain": "epa.gov",
         "page_count": 44,
-        "s3_url": "s3://govscape/epa.gov/air_quality.pdf",
     },
 ]
 
@@ -88,7 +88,8 @@ def test_unknown_pdf_name_not_in_result(index):
 def test_no_predicate_result_shape(index):
     result = index.search(["solar_grid.pdf"])
     record = result["solar_grid.pdf"][0]
-    assert record["pdf_name"] == "solar_grid.pdf"
+    assert record["digest"] == "solar_grid.pdf"
+    assert record["pretty_name"] == "Solar Grid Analysis"
     assert record["sub_domain"] == "energy.gov"
     assert record["page_count"] == 18
     # crawl_date must be normalised to YYYYMMDD
@@ -96,7 +97,7 @@ def test_no_predicate_result_shape(index):
 
 
 def test_domain_predicate(index):
-    all_names = [r["pdf_name"] for r in _RECORDS]
+    all_names = [r["digest"] for r in _RECORDS]
     result = index.search(all_names, [EqualityPredicate("sub_domain", "epa.gov")])
     for entries in result.values():
         for entry in entries:
@@ -106,7 +107,7 @@ def test_domain_predicate(index):
 
 
 def test_date_predicate_crawled_after(index):
-    all_names = [r["pdf_name"] for r in _RECORDS]
+    all_names = [r["digest"] for r in _RECORDS]
     result = index.search(all_names, [RangePredicate("crawl_date", min_val="20230101")])
     for entries in result.values():
         for entry in entries:
@@ -115,7 +116,7 @@ def test_date_predicate_crawled_after(index):
 
 
 def test_date_predicate_crawled_before(index):
-    all_names = [r["pdf_name"] for r in _RECORDS]
+    all_names = [r["digest"] for r in _RECORDS]
     result = index.search(all_names, [RangePredicate("crawl_date", max_val="20221231")])
     for entries in result.values():
         for entry in entries:
@@ -123,7 +124,7 @@ def test_date_predicate_crawled_before(index):
 
 
 def test_all_predicates_combined(index):
-    all_names = [r["pdf_name"] for r in _RECORDS]
+    all_names = [r["digest"] for r in _RECORDS]
     result = index.search(
         all_names,
         [

--- a/interface/src/lib/components/PDFPreview.svelte
+++ b/interface/src/lib/components/PDFPreview.svelte
@@ -153,7 +153,7 @@
   <div class="modal-backdrop" on:click={closeModal}>
     <div class="modal-content" on:click|stopPropagation>
       <div class="modal-header">
-        <h5 class="modal-title">{pdfData?.crawlUrl?.split('/').pop().replaceAll("\%20", " ") || ''}</h5>
+        <h5 class="modal-title">{(pdfData?.prettyName && pdfData.prettyName !== 'Unknown') ? pdfData.prettyName : (pdfData?.crawlUrl?.split('/').pop().replaceAll("\%20", " ") || '')}</h5>
         <button class="btn-close" on:click={closeModal}>
           <i class="bi bi-x"></i>
         </button>

--- a/interface/src/lib/components/PDFPreview.svelte
+++ b/interface/src/lib/components/PDFPreview.svelte
@@ -153,7 +153,7 @@
   <div class="modal-backdrop" on:click={closeModal}>
     <div class="modal-content" on:click|stopPropagation>
       <div class="modal-header">
-        <h5 class="modal-title">{(pdfData?.prettyName && pdfData.prettyName !== 'Unknown') ? pdfData.prettyName : (pdfData?.crawlUrl?.split('/').pop().replaceAll("\%20", " ") || '')}</h5>
+        <h5 class="modal-title">{pdfData?.prettyName || pdfData?.crawlUrl?.split('/').pop().replaceAll("\%20", " ") || ''}</h5>
         <button class="btn-close" on:click={closeModal}>
           <i class="bi bi-x"></i>
         </button>

--- a/interface/src/lib/components/ResultsGrid.svelte
+++ b/interface/src/lib/components/ResultsGrid.svelte
@@ -158,7 +158,7 @@
           />
         </div>
         <div class="result-info">
-          <div class="info-name">{(result.prettyName && result.prettyName !== 'Unknown') ? result.prettyName : result.crawlUrl.split('/').pop().replaceAll("\%20", " ")}</div>
+          <div class="info-name">{result.prettyName || result.crawlUrl.split('/').pop().replaceAll("\%20", " ")}</div>
           <div class="info-subdomain">{result.subDomain || 'Not Available'}</div>
         </div>
       </div>

--- a/interface/src/lib/components/ResultsGrid.svelte
+++ b/interface/src/lib/components/ResultsGrid.svelte
@@ -68,7 +68,7 @@
     previousPage = currentPage;
   })();
 
-  function handlePDFSelect(pdf, page, crawlDate, crawlUrl, subDomain, crawlInstances, hasMoreCrawls) {
+  function handlePDFSelect(pdf, page, crawlDate, crawlUrl, subDomain, crawlInstances, hasMoreCrawls, prettyName) {
     const pdfId = pdf.split('/').pop();
 
     try {
@@ -81,7 +81,7 @@
       });
     } catch (e) {}
 
-    dispatch('pdfSelect', { pdf, page, id: pdfId, crawlDate, crawlUrl, subDomain, crawlInstances, hasMoreCrawls });
+    dispatch('pdfSelect', { pdf, page, id: pdfId, crawlDate, crawlUrl, subDomain, crawlInstances, hasMoreCrawls, prettyName });
   }
 
   function updatePageInURL(newPage) {
@@ -149,7 +149,7 @@
   <div class="masonry-wrapper" bind:this={gridElement}>
     {#each results as result (result.pdf + result.page)}
     <div class="grid-item">
-      <div class="result-card" on:click={() => handlePDFSelect(result.pdf, result.page, result.crawlDate, result.crawlUrl, result.subDomain, result.crawlInstances, result.hasMoreCrawls)}>
+      <div class="result-card" on:click={() => handlePDFSelect(result.pdf, result.page, result.crawlDate, result.crawlUrl, result.subDomain, result.crawlInstances, result.hasMoreCrawls, result.prettyName)}>
         <div class="image-container">
           <img
             src={result.jpeg}
@@ -158,7 +158,7 @@
           />
         </div>
         <div class="result-info">
-          <div class="info-name">{result.crawlUrl.split('/').pop().replaceAll("\%20", " ")}</div>
+          <div class="info-name">{(result.prettyName && result.prettyName !== 'Unknown') ? result.prettyName : result.crawlUrl.split('/').pop().replaceAll("\%20", " ")}</div>
           <div class="info-subdomain">{result.subDomain || 'Not Available'}</div>
         </div>
       </div>

--- a/interface/src/routes/search/+page.svelte
+++ b/interface/src/routes/search/+page.svelte
@@ -12,8 +12,8 @@
   let selectedPDF = null;
 
   function handlePDFSelect(event) {
-    const { id, page, crawlDate, crawlUrl, subDomain, crawlInstances, hasMoreCrawls } = event.detail || {};
-    selectedPDF = { id, page, crawlDate, crawlUrl, subDomain, crawlInstances, hasMoreCrawls };
+    const { id, page, crawlDate, crawlUrl, subDomain, crawlInstances, hasMoreCrawls, prettyName } = event.detail || {};
+    selectedPDF = { id, page, crawlDate, crawlUrl, subDomain, crawlInstances, hasMoreCrawls, prettyName };
     shouldShowPreview = true;
   }
 

--- a/scripts/indexing/generate_index_metadata.py
+++ b/scripts/indexing/generate_index_metadata.py
@@ -138,6 +138,8 @@ def main():
         ).fetchall()
         con.close()
 
+        pretty_names = {r["digest"]: r.get("pretty_name", "") for r in rows}
+
         print("Building Index")
         index.build_index()
         cur_batch = []
@@ -147,12 +149,10 @@ def main():
                 {
                     "crawl_url": url,
                     "crawl_date": crawl_date,
-                    "pdf_name": digest,
+                    "digest": digest,
+                    "pretty_name": pretty_names.get(digest, ""),
                     "sub_domain": extract_subdomain(url),
                     "page_count": num_pages,
-                    "s3_url": data_loader.to_uri(
-                        os.path.join("archive/2020/PDFs", f"{digest}.pdf")
-                    ),
                 }
             )
             if len(cur_batch) >= 1000:
@@ -194,10 +194,11 @@ def _read_metadata_row(filepath):
         with open(filepath) as f:
             metadata_json = json.load(f)
         digest_val = os.path.dirname(filepath).split("/")[-1]
-        os.remove(filepath)  # Clean up the file after reading
         return {
             "digest": digest_val,
             "num_pages": metadata_json.get("num_pages", None),
+            "creation_date": metadata_json.get("creation_date", None),
+            "pretty_name": metadata_json.get("pretty_name", ""),
         }
     except Exception as exc:
         print(f"Error reading {filepath}: {exc}")


### PR DESCRIPTION
Previously, we were using the digest as the pdf name. This pr separates the notion of the digest as a pdf identifier and the human readable pretty_name of a pdf. 

Currently the pretty_name is just whatever is stored in the pdf metadata "Title" attribute.