### PR TITLE
Ocr

### DIFF
--- a/govscape/govscape/pdf_to_embed.py
+++ b/govscape/govscape/pdf_to_embed.py
@@ -1,0 +1,429 @@
+import io
+import json
+import logging
+import os
+import re
+import shutil
+import time
+from multiprocessing import get_context
+from pathlib import Path
+
+import numpy as np
+
+import fitz
+import pypdfium2
+from PIL import Image, ImageFile
+from sentence_transformers import LoggingHandler
+
+from .text_embedding_models import (
+    BGE_TextEmbeddingModel,
+    BGESmall_TextEmbeddingModel,
+    Dummy_TextEmbeddingModel,
+    ST_TextEmbeddingModel,
+)
+from .utils import read_txt_file
+from .visual_embedding_models import (
+    CLIP_VisualEmbeddingModel,
+    Dummy_VisualEmbeddingModel,
+)
+
+ImageFile.LOAD_TRUNCATED_IMAGES = True
+
+# global vars ---------------------------------------------------------------
+GPU_BATCH_SIZE = 2
+BATCH_SIZE = 64
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    format="%(asctime)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    level=logging.INFO,
+    handlers=[LoggingHandler()],
+)
+
+
+def natural_key(s):
+    return [
+        int(text) if text.isdigit() else text.lower() for text in re.split(r"(\d+)", s)
+    ]
+
+
+class PDFsToEmbeddings:
+    def __init__(self, pdf_directory, data_dir, text_model_type, visual_model_type):
+        self.pdfs_path = pdf_directory
+        self.txts_path = data_dir + "/txt"
+        self.img_path = data_dir + "/img"
+        self.extracted_img_path = data_dir + "/img_extracted"
+        self.embeddings_path = data_dir + "/embeddings"
+        self.embeddings_img_path = data_dir + "/embeddings_img_pg"
+        self.embeddings_img_e_path = data_dir + "/embeddings_img_extracted"
+        self.index_keyword_directory = data_dir + "/index_keyword"
+        self.metadata_dir = data_dir + "/metadata"
+        self.cpu_count = os.cpu_count()
+
+        if text_model_type == "ST":
+            self.text_model = ST_TextEmbeddingModel()
+        elif text_model_type == "BGE":
+            self.text_model = BGE_TextEmbeddingModel()
+        elif text_model_type == "BGESmall":
+            self.text_model = BGESmall_TextEmbeddingModel()
+        elif text_model_type == "Dummy":
+            self.text_model = Dummy_TextEmbeddingModel()
+        else:
+            raise ValueError("Unsupported model type")
+
+        if visual_model_type == "CLIP":
+            self.visual_model = CLIP_VisualEmbeddingModel()
+        elif visual_model_type == "Dummy":
+            self.visual_model = Dummy_VisualEmbeddingModel()
+        else:
+            raise ValueError("Unsupported model type")
+
+    # converts a single pdf file to txt and img files (one of each per page)
+    @staticmethod
+    def convert_pdf_to_txt_img_and_metadata(
+        txts_path, imgs_path, pdfs_path, metadata_dir, pdf_file
+    ):
+        pdf_name = os.path.splitext(os.path.basename(pdf_file))[0]
+        pdf_path = os.path.join(pdfs_path, pdf_file)
+        pdf_txt_subdir = os.path.join(txts_path, pdf_name)
+        pdf_img_subdir = os.path.join(imgs_path, pdf_name)
+        os.makedirs(pdf_txt_subdir, exist_ok=True)
+        os.makedirs(pdf_img_subdir, exist_ok=True)
+        try:
+            pdf = pypdfium2.PdfDocument(pdf_path)
+            num_pages = len(pdf)
+            gov_name = pdf.get_metadata_value("Title")
+
+            # Create Metadata JSON
+            json_data = {}
+            timestamp = pdf.get_metadata_value("CreationDate")
+            if len(gov_name) == 0:
+                gov_name = "Unknown"
+            if len(timestamp) == 0:
+                timestamp = "Unknown"
+            json_data["gov_name"] = gov_name
+            json_data["timestamp"] = timestamp
+            json_data["num_pages"] = num_pages
+            pdf_metadata_dir = os.path.join(
+                metadata_dir, os.path.splitext(os.path.basename(pdf_file))[0]
+            )
+            os.makedirs(pdf_metadata_dir, exist_ok=True)
+            json_file_path = os.path.join(pdf_metadata_dir, "metadata.json")
+            with open(json_file_path, "w") as json_file:
+                json.dump(json_data, json_file, indent=4)
+
+            # Gather text and image for each page
+            text = []
+            images = []
+            for i in range(num_pages):
+                page = pdf[i]
+                # Extract text
+                page_text = page.get_textpage().get_text_bounded()
+                text.append(page_text)
+                # Render image
+                pil_image = page.render(scale=1.0).to_pil()
+                images.append(pil_image)
+        except Exception:
+            return False
+
+        for page_num, page_text in enumerate(text):
+            txt_file_path = os.path.join(pdf_txt_subdir, f"{pdf_name}_{page_num}.txt")
+            if page_text and len(page_text) != 0:
+                with open(txt_file_path, "w", encoding="utf-8") as text_file:
+                    text_file.write(page_text)
+
+            img_file_path = os.path.join(pdf_img_subdir, f"{pdf_name}_{page_num}.jpeg")
+            image = images[page_num]
+            image.save(img_file_path, format="JPEG")
+        return True
+
+    # converts dir of pdfs -> dir of subdirs of txt files of each page
+    # AKA OVERALL PDFS -> TXTS
+    def convert_pdfs_to_txt_img_and_metadata(self, pdf_files):
+        if not os.path.exists(self.txts_path):
+            os.makedirs(self.txts_path)
+        ctx = get_context("forkserver")
+        with ctx.Pool(processes=self.cpu_count) as pool:
+            results = pool.starmap(
+                self.convert_pdf_to_txt_img_and_metadata,
+                [
+                    (
+                        self.txts_path,
+                        self.img_path,
+                        self.pdfs_path,
+                        self.metadata_dir,
+                        file,
+                    )
+                    for file in pdf_files
+                ],
+            )
+        return sum(results)
+
+    # ----------------------------------------
+    # 1. dir pdf -> dir img (entire page) -> dir embed (entire page) shared with og
+    #    embed dir
+    # ----------------------------------------
+    @staticmethod
+    def _convert_img_embedding_to_files_batch(embed_and_paths):
+        embed, embed_file_paths = embed_and_paths
+        for output_path, embedding in zip(embed_file_paths, embed, strict=False):
+            np.save(output_path, embedding)
+
+    def convert_img_embedding_to_files(self, embed, embed_file_paths):
+        # split the embedding up into chunks
+        chunks = np.array_split(embed, self.cpu_count)
+        # chunks = np.array_split(embed, 2)
+        chunk_embed_file_paths = []
+        start = 0
+        for i in range(len(chunks)):
+            end = chunks[i].shape[0]
+            chunk_embed_file_paths.append(embed_file_paths[start : start + end])
+            start = start + end
+
+        if len(chunks) != len(chunk_embed_file_paths):
+            raise Exception(
+                "chunks and chunk_embed_file_paths should be the same length."
+            )
+
+        ctx = get_context("spawn")
+        with ctx.Pool(processes=self.cpu_count) as pool:
+            pool.map(
+                self._convert_img_embedding_to_files_batch,
+                zip(chunks, chunk_embed_file_paths, strict=False),
+            )
+
+    # ----------------------------------------
+    # dir pdf -> dir img (extracted) -> dir embed (extracted) shared with og
+    # embed dir
+    # ----------------------------------------
+
+    # single pdf -> extracted img, extracted img embedding (using og embed dir)
+    # multi gpu extract images below
+    @staticmethod
+    def extract_img_pdfs(
+        pdf_directory, extracted_img_path, embeddings_img_e_path, pdf_path
+    ):
+        full_pdf_path = Path(pdf_directory) / Path(pdf_path)
+        output_img_dir_path = Path(extracted_img_path) / Path(pdf_path).stem
+        output_img_dir_path.mkdir(parents=True, exist_ok=True)
+
+        try:
+            with fitz.open(full_pdf_path) as pdf_doc:
+                pdf_name = os.path.splitext(os.path.basename(pdf_path))[0]
+
+                empty = True
+                for page_num in range(len(pdf_doc)):
+                    page = pdf_doc[page_num]
+                    for i, img in enumerate(page.get_images(full=True)):
+                        if i == 4:  # four images max per page extracted
+                            break
+                        empty = False
+
+                        xref = img[0]
+                        image_dict = pdf_doc.extract_image(xref)
+                        image_bytes = image_dict["image"]
+
+                        try:
+                            image = Image.open(io.BytesIO(image_bytes))
+                            image.load()
+                        except Exception:
+                            continue
+
+                        image_path = (
+                            Path(output_img_dir_path)
+                            / f"{pdf_name}_{page_num}_{i}.jpeg"
+                        )
+                        image = image.convert("RGB")
+
+                        if (
+                            image.size[0] < 80
+                            or image.size[1] < 80
+                            or image.size[0] > 7000
+                            or image.size[1] > 7000
+                        ):  # image is too small/big to be considered
+                            continue
+                        image.save(image_path, "JPEG")
+
+                if empty:
+                    shutil.rmtree(output_img_dir_path)
+
+        except Exception as e:
+            logging.error(f"can't open PDF {pdf_path}: {e}")
+            return
+
+    def convert_pdfs_to_extracted_imgs(self, pdf_files):
+        ctx = get_context("spawn")
+        with ctx.Pool(processes=self.cpu_count) as pool:
+            pool.starmap(
+                self.extract_img_pdfs,
+                [
+                    (
+                        self.pdfs_path,
+                        self.extracted_img_path,
+                        self.embeddings_img_e_path,
+                        file,
+                    )
+                    for file in pdf_files
+                ],
+            )
+
+    # ----------------------------------------
+    # Create Text Embeddings
+    # ----------------------------------------
+    @staticmethod
+    def create_metadata_jsons_worker(pdf_files, metadata_dir):
+        for pdf_file in pdf_files:
+            json_data = dict()
+            pdf_path = os.path.join(pdf_file)
+            try:
+                pdf = pypdfium2.PdfDocument(pdf_path)
+                num_pages = len(pdf)
+                # pypdfium2 does not provide metadata directly, so set as Unknown or use another lib if needed
+                gov_name = pdf.get_metadata_value("Title")
+                timestamp = pdf.get_metadata_value("CreationDate")
+                keywords = pdf.get_metadata_value("Keywords")
+                if len(keywords) == 0:
+                    keywords = 'Unknown'
+                if len(gov_name) == 0:
+                    gov_name = 'Unknown'
+                if len(timestamp) == 0:
+                    timestamp = 'Unknown'
+                json_data['gov_name'] = gov_name
+                json_data['timestamp'] = timestamp
+                json_data['num_pages'] = num_pages
+                json_data['keywords'] = keywords
+            except Exception as e:
+                json_data['gov_name'] = 'Unknown'
+                json_data['timestamp'] = 'Unknown'
+                json_data['num_pages'] = 1
+                json_data['keywords'] = 'Unknown'
+                print(f"Skipping invalid PDF {pdf_path}: {e}")
+                continue
+
+            pdf_metadata_dir = os.path.join(metadata_dir, os.path.splitext(os.path.basename(pdf_file))[0])
+            os.makedirs(pdf_metadata_dir, exist_ok=True)
+            json_file_path = os.path.join(pdf_metadata_dir, "metadata.json")
+            with open(json_file_path, "w") as json_file:
+                json.dump(json_data, json_file, indent=4)
+    def convert_subdirs_to_embeddings(txt_path, embed_path):
+        if not os.path.exists(embed_path):
+            os.makedirs(embed_path)
+
+        txt_subdirs_paths = [
+            txt_subdir.path
+            for txt_subdir in os.scandir(txt_path)
+            if txt_subdir.is_dir()
+        ]
+
+        text_batch = []
+        file_batch = []
+        for txt_subdir_path in txt_subdirs_paths:
+            embed_name = os.path.basename(txt_subdir_path)
+            embedding_dir = os.path.join(embed_path, embed_name)
+
+            if not os.path.exists(embedding_dir):
+                os.makedirs(embedding_dir)
+
+            # all txt files in the txt subdir
+            txt_files = os.listdir(txt_subdir_path)
+
+            for txt_file in txt_files:
+                txt_path = os.path.join(txt_subdir_path, txt_file)
+                text = read_txt_file(txt_path)
+                output_path = os.path.join(
+                    embedding_dir, txt_file.replace(".txt", ".npy")
+                )
+                text_batch.append(text)
+                file_batch.append(output_path)
+
+        return text_batch, file_batch
+
+    @staticmethod
+    def convert_embedding_to_files(embeddings, embed_file_paths):
+        for embedding, output_path in zip(embeddings, embed_file_paths, strict=False):
+            np.save(output_path, embedding)
+
+    def compute_text_embeddings(self):
+        # sentences
+        sentences, all_embed_file_paths = self.convert_subdirs_to_embeddings(
+            self.txts_path, self.embeddings_path
+        )
+
+        embeddings = self.text_model.encode_text_batch(sentences)
+        print("Embeddings computed. Shape:", embeddings.shape)
+
+        # put them into embedding files
+        self.convert_embedding_to_files(embeddings, all_embed_file_paths)
+
+    # -------------------------------------------------------------------------------
+    # Create Page Image Embeddings
+    # -------------------------------------------------------------------------------
+    def compute_image_embeddings(self):
+        os.makedirs(self.embeddings_img_path, exist_ok=True)
+        img_paths = []
+        embedding_paths = []
+        for img_subdir in os.scandir(self.img_path):
+            if img_subdir.is_dir():
+                os.makedirs(
+                    os.path.join(self.embeddings_img_path, img_subdir.name),
+                    exist_ok=True,
+                )
+                img_subdir_paths = os.listdir(img_subdir.path)
+                for img_file in img_subdir_paths:
+                    img_paths.append(os.path.join(img_subdir.path, img_file))
+                    embedding_paths.append(
+                        os.path.join(
+                            self.embeddings_img_path,
+                            img_subdir.name,
+                            os.path.splitext(img_file)[0] + ".npy",
+                        )
+                    )
+
+        print("Embedding this many images: ", len(img_paths))
+        emb = self.visual_model.encode_images(img_paths)
+
+        print("Embeddings computed. Shape:", emb.shape)
+        self.convert_img_embedding_to_files(emb, embedding_paths)
+
+    # -------------------------------------------------------------------------------
+    # overall pipeline
+    # -------------------------------------------------------------------------------
+    def pdfs_to_embeddings(
+        self, pdf_files, do_text_embedding, do_img_embedding, do_metadata_collection
+    ):
+        time1 = time.time()
+        pdfs_successfully_parsed = 0
+        if do_text_embedding or do_img_embedding or do_metadata_collection:
+            print("Converting pdfs to txts and page images")
+            pdfs_successfully_parsed = self.convert_pdfs_to_txt_img_and_metadata(
+                pdf_files
+            )
+        print(
+            f"% pdfs successfully parsed: {pdfs_successfully_parsed} / {len(pdf_files)}"
+        )
+
+        time2 = time.time()
+        if do_text_embedding:
+            print("Converting txts to embeddings")
+            self.compute_text_embeddings()
+        time3 = time.time()
+
+        if do_img_embedding:
+            self.compute_image_embeddings()
+
+        time4 = time.time()
+
+        pdf_to_txt_img_metadata = time2 - time1
+        text_embed_time = time3 - time2
+        img_embed_time = time4 - time3
+
+        print("pdf -> txt, img, metadata time: ", pdf_to_txt_img_metadata)
+        print("txt -> embed time: ", text_embed_time)
+        print("img per page -> embed time: ", img_embed_time)
+
+        return (
+            pdf_to_txt_img_metadata,
+            text_embed_time,
+            img_embed_time,
+        )

--- a/govscape/govscape/processing/ocr/__init__.py
+++ b/govscape/govscape/processing/ocr/__init__.py
@@ -1,0 +1,20 @@
+"""
+OCR module for govscape processing.
+
+This module contains abstract base classes and concrete implementations
+for various OCR engines used in document processing.
+"""
+
+from .abstract_ocr import AbstractOCR
+from .olm_ocr import OlmOCR
+from .easy_ocr import EasyOCR
+from .paddle_my_ocr import PaddleMyOCR
+from .ocr_my_pdf import OCRMyPDF
+
+__all__ = [
+    'AbstractOCR',
+    'OlmOCR', 
+    'EasyOCR',
+    'PaddleMyOCR',
+    'OCRMyPDF'
+]

--- a/govscape/govscape/processing/ocr/abstract_ocr.py
+++ b/govscape/govscape/processing/ocr/abstract_ocr.py
@@ -1,0 +1,117 @@
+# AI modified: 2026-04-16, commit: 4a7a81118a560918e0ea7825dce27f3e5a60a340
+"""
+Abstract OCR class for govscape processing.
+
+This module defines the abstract base class that all OCR implementations
+must inherit from.
+"""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
+
+
+class AbstractOCR(ABC):
+    """Abstract base class for OCR implementations.
+    
+    This class defines the interface that all OCR engines must implement
+    to be used within the govscape processing pipeline.
+    """
+    
+    def __init__(self, **kwargs):
+        """Initialize the OCR engine with optional configuration parameters."""
+        self.config = kwargs
+    
+    @abstractmethod
+    def process_image(
+        self, 
+        image_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> str:
+        """Process a single image and extract text.
+        
+        Args:
+            image_path: Path to the image file to process
+            language: Optional language code for OCR (e.g., 'en', 'spa')
+            
+        Returns:
+            Extracted text from the image
+        """
+        pass
+    
+    @abstractmethod
+    def process_pdf(
+        self, 
+        pdf_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> str:
+        """Process a PDF document and extract text.
+        
+        Args:
+            pdf_path: Path to the PDF file to process
+            language: Optional language code for OCR (e.g., 'en', 'spa')
+            
+        Returns:
+            Extracted text from the PDF
+        """
+        pass
+    
+    @abstractmethod
+    def process_batch(
+        self, 
+        file_paths: List[Union[str, Path]], 
+        language: Optional[str] = None
+    ) -> List[Tuple[str, str]]:
+        """Process multiple files and extract text from each.
+        
+        Args:
+            file_paths: List of paths to image or PDF files
+            language: Optional language code for OCR (e.g., 'en', 'spa')
+            
+        Returns:
+            List of tuples containing (file_path, extracted_text)
+        """
+        pass
+    
+    @abstractmethod
+    def process_pdf_per_page(
+        self, 
+        pdf_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> List[str]:
+        """Process a PDF document and extract text per page.
+        
+        Args:
+            pdf_path: Path to the PDF file to process
+            language: Optional language code for OCR (e.g., 'en', 'spa')
+            
+        Returns:
+            List of extracted text for each page
+        """
+        pass
+    
+    @abstractmethod
+    def get_supported_languages(self) -> List[str]:
+        """Get list of supported language codes.
+        
+        Returns:
+            List of supported language codes
+        """
+        pass
+    
+    def _validate_file(self, file_path: Union[str, Path]) -> Path:
+        """Validate that a file exists and return a Path object.
+        
+        Args:
+            file_path: Path to validate
+            
+        Returns:
+            Path object for the file
+            
+        Raises:
+            FileNotFoundError: If the file does not exist
+        """
+        path = Path(file_path)
+        if not path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+        return path

--- a/govscape/govscape/processing/ocr/easy_ocr.py
+++ b/govscape/govscape/processing/ocr/easy_ocr.py
@@ -1,0 +1,178 @@
+# AI modified: 2026-04-16, commit: 4a7a81118a560918e0ea7825dce27f3e5a60a340
+"""
+EasyOCR implementation for govscape processing.
+
+This module provides an OCR implementation using the EasyOCR library.
+"""
+
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
+
+from .abstract_ocr import AbstractOCR
+
+
+class EasyOCR(AbstractOCR):
+    """OCR implementation using EasyOCR library."""
+    
+    def __init__(self, **kwargs):
+        """Initialize EasyOCR with optional configuration.
+        
+        Args:
+            **kwargs: Configuration parameters for EasyOCR
+        """
+        super().__init__(**kwargs)
+        try:
+            import easyocr
+            self.reader = easyocr.Reader(
+                lang_list=self.config.get('languages', ['en']),
+                gpu=self.config.get('gpu', False),
+                model_storage_directory=self.config.get('model_dir', None),
+                download_enabled=self.config.get('download_enabled', True)
+            )
+        except ImportError:
+            raise ImportError("EasyOCR not installed. Please install with: pip install easyocr")
+    
+    def process_image(
+        self, 
+        image_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> str:
+        """Process a single image and extract text using EasyOCR.
+        
+        Args:
+            image_path: Path to the image file to process
+            language: Optional language code for OCR
+            
+        Returns:
+            Extracted text from the image
+        """
+        path = self._validate_file(image_path)
+        
+        # If language is specified, create a new reader with that language
+        if language:
+            import easyocr
+            reader = easyocr.Reader([language], gpu=self.config.get('gpu', False))
+        else:
+            reader = self.reader
+        
+        # Perform OCR
+        results = reader.readtext(str(path))
+        
+        # Extract text from results
+        extracted_text = ' '.join([result[1] for result in results])
+        
+        return extracted_text
+    
+    def process_pdf(
+        self, 
+        pdf_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> str:
+        """Process a PDF document and extract text using EasyOCR.
+        
+        Args:
+            pdf_path: Path to the PDF file to process
+            language: Optional language code for OCR
+            
+        Returns:
+            Extracted text from the PDF
+        """
+        path = self._validate_file(pdf_path)
+        
+        # Convert PDF to images and process each page
+        try:
+            from pdf2image import convert_from_path
+        except ImportError:
+            raise ImportError("pdf2image not installed. Please install with: pip install pdf2image")
+        
+        # Convert PDF to images
+        images = convert_from_path(str(path))
+        
+        # Process each page
+        all_text = []
+        for image in images:
+            # Save image temporarily to process
+            import tempfile
+            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as temp_file:
+                image.save(temp_file.name, 'PNG')
+                text = self.process_image(temp_file.name, language)
+                all_text.append(text)
+        
+        return '\n\n'.join(all_text)
+    
+    def process_pdf_per_page(
+        self, 
+        pdf_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> List[str]:
+        """Process a PDF document and extract text per page using EasyOCR.
+        
+        Args:
+            pdf_path: Path to the PDF file to process
+            language: Optional language code for OCR
+            
+        Returns:
+            List of extracted text for each page
+        """
+        path = self._validate_file(pdf_path)
+        
+        # Convert PDF to images and process each page
+        try:
+            from pdf2image import convert_from_path
+        except ImportError:
+            raise ImportError("pdf2image not installed. Please install with: pip install pdf2image")
+        
+        # Convert PDF to images
+        images = convert_from_path(str(path))
+        
+        # Process each page
+        page_texts = []
+        for image in images:
+            # Save image temporarily to process
+            import tempfile
+            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as temp_file:
+                image.save(temp_file.name, 'PNG')
+                text = self.process_image(temp_file.name, language)
+                page_texts.append(text.strip())
+        
+        return page_texts
+    
+    def process_batch(
+        self, 
+        file_paths: List[Union[str, Path]], 
+        language: Optional[str] = None
+    ) -> List[Tuple[str, str]]:
+        """Process multiple files and extract text from each.
+        
+        Args:
+            file_paths: List of paths to image or PDF files
+            language: Optional language code for OCR
+            
+        Returns:
+            List of tuples containing (file_path, extracted_text)
+        """
+        results = []
+        for file_path in file_paths:
+            try:
+                path = Path(file_path)
+                if path.suffix.lower() == '.pdf':
+                    text = self.process_pdf(file_path, language)
+                else:
+                    text = self.process_image(file_path, language)
+                results.append((str(file_path), text))
+            except Exception as e:
+                results.append((str(file_path), f"Error: {str(e)}"))
+        return results
+    
+    def get_supported_languages(self) -> List[str]:
+        """Get list of supported language codes for EasyOCR.
+        
+        Returns:
+            List of supported language codes
+        """
+        # EasyOCR supports many languages, returning common ones
+        return [
+            'en', 'ch_sim', 'ch_tra', 'ja', 'ko', 'fr', 'de', 'es', 'it', 'pt',
+            'ru', 'ar', 'hi', 'th', 'vi', 'tr', 'pl', 'nl', 'sv', 'da', 'no',
+            'fi', 'cs', 'sk', 'hu', 'ro', 'bg', 'hr', 'el', 'lt', 'lv', 'et'
+        ]

--- a/govscape/govscape/processing/ocr/ocr_my_pdf.py
+++ b/govscape/govscape/processing/ocr/ocr_my_pdf.py
@@ -1,0 +1,221 @@
+# AI modified: 2026-04-16, commit: 4a7a81118a560918e0ea7825dce27f3e5a60a340
+"""
+OCRMyPDF implementation for govscape processing.
+
+This module provides an OCR implementation using the OCRMyPDF library.
+"""
+
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
+import PyPDF2
+
+from .abstract_ocr import AbstractOCR
+
+
+class OCRMyPDF(AbstractOCR):
+    """OCR implementation using OCRMyPDF library."""
+    
+    def __init__(self, **kwargs):
+        """Initialize OCRMyPDF with optional configuration.
+        
+        Args:
+            **kwargs: Configuration parameters for OCRMyPDF
+        """
+        super().__init__(**kwargs)
+        try:
+            import ocrmypdf
+            self.ocrmypdf = ocrmypdf
+        except ImportError:
+            raise ImportError("OCRMyPDF not installed. Please install with: pip install ocrmypdf")
+    
+    def process_image(
+        self, 
+        image_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> str:
+        """Process a single image and extract text using OCRMyPDF.
+        
+        Args:
+            image_path: Path to the image file to process
+            language: Optional language code for OCR
+            
+        Returns:
+            Extracted text from the image
+        """
+        path = self._validate_file(image_path)
+        
+        # OCRMyPDF works with PDFs, so convert image to PDF first
+        import img2pdf
+        import tempfile
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Convert image to PDF
+            pdf_path = Path(temp_dir) / "temp.pdf"
+            with open(pdf_path, 'wb') as f:
+                f.write(img2pdf.convert(str(path)))
+            
+            # Process PDF with OCR
+            output_pdf_path = Path(temp_dir) / "output.pdf"
+            
+            # Set OCR options
+            ocr_options = {
+                'language': language or self.config.get('language', 'eng'),
+                'output_type': 'pdfa',
+                'skip_text': True,
+                'force_ocr': self.config.get('force_ocr', False),
+                'optimize': self.config.get('optimize', 1),
+                'jobs': self.config.get('jobs', 1),
+            }
+            
+            # Perform OCR
+            self.ocrmypdf.ocr(str(pdf_path), str(output_pdf_path), **ocr_options)
+            
+            # Extract text from the output PDF
+            try:
+                with open(output_pdf_path, 'rb') as f:
+                    reader = PyPDF2.PdfReader(f)
+                    text = ''
+                    for page in reader.pages:
+                        text += page.extract_text() + '\n'
+                return text.strip()
+            except ImportError:
+                raise ImportError("PyPDF2 not installed. Please install with: pip install PyPDF2")
+    
+    def process_pdf(
+        self, 
+        pdf_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> str:
+        """Process a PDF document and extract text using OCRMyPDF.
+        
+        Args:
+            pdf_path: Path to the PDF file to process
+            language: Optional language code for OCR
+            
+        Returns:
+            Extracted text from the PDF
+        """
+        path = self._validate_file(pdf_path)
+        
+        import tempfile
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_pdf_path = Path(temp_dir) / "output.pdf"
+            
+            # Set OCR options
+            ocr_options = {
+                'language': language or self.config.get('language', 'eng'),
+                'output_type': 'pdfa',
+                'skip_text': True,
+                'force_ocr': self.config.get('force_ocr', False),
+                'optimize': self.config.get('optimize', 1),
+                'jobs': self.config.get('jobs', 1),
+            }
+            
+            # Perform OCR
+            self.ocrmypdf.ocr(str(path), str(output_pdf_path), **ocr_options)
+            
+            # Extract text from the output PDF
+            try:
+                with open(output_pdf_path, 'rb') as f:
+                    reader = PyPDF2.PdfReader(f)
+                    text = ''
+                    for page in reader.pages:
+                        text += page.extract_text() + '\n'
+                return text.strip()
+            except ImportError:
+                raise ImportError("PyPDF2 not installed. Please install with: pip install PyPDF2")
+    
+    def process_pdf_per_page(
+        self, 
+        pdf_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> List[str]:
+        """Process a PDF document and extract text per page using OCRMyPDF.
+        
+        Args:
+            pdf_path: Path to the PDF file to process
+            language: Optional language code for OCR
+            
+        Returns:
+            List of extracted text for each page
+        """
+        path = self._validate_file(pdf_path)
+        
+        import tempfile
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_pdf_path = Path(temp_dir) / "output.pdf"
+            
+            # Set OCR options
+            ocr_options = {
+                'language': language or self.config.get('language', 'eng'),
+                'output_type': 'pdfa',
+                'skip_text': True,
+                'force_ocr': self.config.get('force_ocr', False),
+                'optimize': self.config.get('optimize', 1),
+                'jobs': self.config.get('jobs', 1),
+            }
+            
+            # Perform OCR
+            self.ocrmypdf.ocr(str(path), str(output_pdf_path), **ocr_options)
+            
+            # Extract text per page from the output PDF
+            try:
+                with open(output_pdf_path, 'rb') as f:
+                    reader = PyPDF2.PdfReader(f)
+                    page_texts = []
+                    for page in reader.pages:
+                        text = page.extract_text() or ''
+                        page_texts.append(text.strip())
+                return page_texts
+            except ImportError:
+                raise ImportError("PyPDF2 not installed. Please install with: pip install PyPDF2")
+    
+    def process_batch(
+        self, 
+        file_paths: List[Union[str, Path]], 
+        language: Optional[str] = None
+    ) -> List[Tuple[str, str]]:
+        """Process multiple files and extract text from each.
+        
+        Args:
+            file_paths: List of paths to image or PDF files
+            language: Optional language code for OCR
+            
+        Returns:
+            List of tuples containing (file_path, extracted_text)
+        """
+        results = []
+        for file_path in file_paths:
+            try:
+                path = Path(file_path)
+                if path.suffix.lower() == '.pdf':
+                    text = self.process_pdf(file_path, language)
+                else:
+                    text = self.process_image(file_path, language)
+                results.append((str(file_path), text))
+            except Exception as e:
+                results.append((str(file_path), f"Error: {str(e)}"))
+        return results
+    
+    def get_supported_languages(self) -> List[str]:
+        """Get list of supported language codes for OCRMyPDF.
+        
+        Note: OCRMyPDF uses Tesseract language data files.
+        
+        Returns:
+            List of supported language codes
+        """
+        # OCRMyPDF uses Tesseract, which supports many languages
+        # Common language codes are listed here
+        return [
+            'eng', 'spa', 'fra', 'deu', 'ita', 'por', 'rus', 'jpn', 'kor',
+            'chi_sim', 'chi_tra', 'ara', 'hin', 'tha', 'vie', 'tur', 'pol',
+            'nld', 'swe', 'dan', 'nor', 'fin', 'ces', 'slk', 'hun', 'ron',
+            'bul', 'hrv', 'ell', 'lit', 'lav', 'est', 'ukr', 'srp', 'slv',
+            'cat', 'eus', 'glg', 'isl', 'gle', 'cym', 'bre', 'oci', 'cos',
+            'ast', 'anp', 'awa', 'bho', 'mag', 'mai', 'new', 'sat', 'doi',
+            'kok', 'gon', 'kfy', 'lah', 'pan', 'snd', 'skr', 'urdu'
+        ]

--- a/govscape/govscape/processing/ocr/olm_ocr.py
+++ b/govscape/govscape/processing/ocr/olm_ocr.py
@@ -1,0 +1,115 @@
+# AI modified: 2026-04-16, commit: 4a7a81118a560918e0ea7825dce27f3e5a60a340
+"""
+OlmOCR implementation for govscape processing.
+
+This module provides an OCR implementation using the OlmOCR engine.
+"""
+
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
+
+from .abstract_ocr import AbstractOCR
+
+
+class OlmOCR(AbstractOCR):
+    """OCR implementation using OlmOCR engine."""
+    
+    def __init__(self, **kwargs):
+        """Initialize OlmOCR with optional configuration.
+        
+        Args:
+            **kwargs: Configuration parameters for OlmOCR
+        """
+        super().__init__(**kwargs)
+        # TODO: Initialize OlmOCR engine with config
+        self.engine = None
+    
+    def process_image(
+        self, 
+        image_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> str:
+        """Process a single image and extract text using OlmOCR.
+        
+        Args:
+            image_path: Path to the image file to process
+            language: Optional language code for OCR
+            
+        Returns:
+            Extracted text from the image
+        """
+        path = self._validate_file(image_path)
+        # TODO: Implement OlmOCR image processing
+        raise NotImplementedError("OlmOCR image processing not yet implemented")
+    
+    def process_pdf(
+        self, 
+        pdf_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> str:
+        """Process a PDF document and extract text using OlmOCR.
+        
+        Args:
+            pdf_path: Path to the PDF file to process
+            language: Optional language code for OCR
+            
+        Returns:
+            Extracted text from the PDF
+        """
+        path = self._validate_file(pdf_path)
+        # TODO: Implement OlmOCR PDF processing
+        raise NotImplementedError("OlmOCR PDF processing not yet implemented")
+    
+    def process_pdf_per_page(
+        self, 
+        pdf_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> List[str]:
+        """Process a PDF document and extract text per page using OlmOCR.
+        
+        Args:
+            pdf_path: Path to the PDF file to process
+            language: Optional language code for OCR
+            
+        Returns:
+            List of extracted text for each page
+        """
+        path = self._validate_file(pdf_path)
+        # TODO: Implement OlmOCR per-page PDF processing
+        raise NotImplementedError("OlmOCR per-page PDF processing not yet implemented")
+    
+    def process_batch(
+        self, 
+        file_paths: List[Union[str, Path]], 
+        language: Optional[str] = None
+    ) -> List[Tuple[str, str]]:
+        """Process multiple files and extract text from each.
+        
+        Args:
+            file_paths: List of paths to image or PDF files
+            language: Optional language code for OCR
+            
+        Returns:
+            List of tuples containing (file_path, extracted_text)
+        """
+        results = []
+        for file_path in file_paths:
+            try:
+                path = Path(file_path)
+                if path.suffix.lower() == '.pdf':
+                    text = self.process_pdf(file_path, language)
+                else:
+                    text = self.process_image(file_path, language)
+                results.append((str(file_path), text))
+            except Exception as e:
+                results.append((str(file_path), f"Error: {str(e)}"))
+        return results
+    
+    def get_supported_languages(self) -> List[str]:
+        """Get list of supported language codes for OlmOCR.
+        
+        Returns:
+            List of supported language codes
+        """
+        # TODO: Return actual supported languages from OlmOCR
+        return ['en']

--- a/govscape/govscape/processing/ocr/paddle_my_ocr.py
+++ b/govscape/govscape/processing/ocr/paddle_my_ocr.py
@@ -1,0 +1,191 @@
+# AI modified: 2026-04-16, commit: 4a7a81118a560918e0ea7825dce27f3e5a60a340
+"""
+PaddleMyOCR implementation for govscape processing.
+
+This module provides an OCR implementation using PaddleOCR.
+"""
+
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
+
+from .abstract_ocr import AbstractOCR
+
+
+class PaddleMyOCR(AbstractOCR):
+    """OCR implementation using PaddleOCR library."""
+    
+    def __init__(self, **kwargs):
+        """Initialize PaddleMyOCR with optional configuration.
+        
+        Args:
+            **kwargs: Configuration parameters for PaddleOCR
+        """
+        super().__init__(**kwargs)
+        try:
+            from paddleocr import PaddleOCR
+            self.ocr = PaddleOCR(
+                lang=self.config.get('language', 'en'),
+                use_gpu=self.config.get('gpu', False),
+                use_angle_cls=self.config.get('use_angle_cls', True),
+                det_model_dir=self.config.get('det_model_dir', None),
+                rec_model_dir=self.config.get('rec_model_dir', None),
+                cls_model_dir=self.config.get('cls_model_dir', None),
+            )
+        except ImportError:
+            raise ImportError("PaddleOCR not installed. Please install with: pip install paddleocr")
+    
+    def process_image(
+        self, 
+        image_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> str:
+        """Process a single image and extract text using PaddleOCR.
+        
+        Args:
+            image_path: Path to the image file to process
+            language: Optional language code for OCR
+            
+        Returns:
+            Extracted text from the image
+        """
+        path = self._validate_file(image_path)
+        
+        # If language is specified, create a new OCR instance
+        if language:
+            from paddleocr import PaddleOCR
+            ocr = PaddleOCR(lang=language, use_gpu=self.config.get('gpu', False))
+        else:
+            ocr = self.ocr
+        
+        # Perform OCR
+        result = ocr.ocr(str(path), cls=True)
+        
+        # Extract text from results
+        extracted_text = ''
+        if result and result[0]:
+            for line in result[0]:
+                if line and len(line) >= 2:
+                    extracted_text += line[1][0] + '\n'
+        
+        return extracted_text.strip()
+    
+    def process_pdf_per_page(
+        self, 
+        pdf_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> List[str]:
+        """Process a PDF document and extract text per page using PaddleOCR.
+        
+        Args:
+            pdf_path: Path to the PDF file to process
+            language: Optional language code for OCR
+            
+        Returns:
+            List of extracted text for each page
+        """
+        path = self._validate_file(pdf_path)
+        
+        # Convert PDF to images and process each page
+        try:
+            from pdf2image import convert_from_path
+        except ImportError:
+            raise ImportError("pdf2image not installed. Please install with: pip install pdf2image")
+        
+        # Convert PDF to images
+        images = convert_from_path(str(path))
+        
+        # Process each page
+        page_texts = []
+        for image in images:
+            # Save image temporarily to process
+            import tempfile
+            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as temp_file:
+                image.save(temp_file.name, 'PNG')
+                text = self.process_image(temp_file.name, language)
+                page_texts.append(text.strip())
+        
+        return page_texts
+    
+    def process_pdf(
+        self, 
+        pdf_path: Union[str, Path], 
+        language: Optional[str] = None
+    ) -> str:
+        """Process a PDF document and extract text using PaddleOCR.
+        
+        Args:
+            pdf_path: Path to the PDF file to process
+            language: Optional language code for OCR
+            
+        Returns:
+            Extracted text from the PDF
+        """
+        path = self._validate_file(pdf_path)
+        
+        # Convert PDF to images and process each page
+        try:
+            from pdf2image import convert_from_path
+        except ImportError:
+            raise ImportError("pdf2image not installed. Please install with: pip install pdf2image")
+        
+        # Convert PDF to images
+        images = convert_from_path(str(path))
+        
+        # Process each page
+        all_text = []
+        for i, image in enumerate(images):
+            # Save image temporarily to process
+            import tempfile
+            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as temp_file:
+                image.save(temp_file.name, 'PNG')
+                text = self.process_image(temp_file.name, language)
+                all_text.append(f"--- Page {i+1} ---\n{text}")
+        
+        return '\n\n'.join(all_text)
+    
+    def process_batch(
+        self, 
+        file_paths: List[Union[str, Path]], 
+        language: Optional[str] = None
+    ) -> List[Tuple[str, str]]:
+        """Process multiple files and extract text from each.
+        
+        Args:
+            file_paths: List of paths to image or PDF files
+            language: Optional language code for OCR
+            
+        Returns:
+            List of tuples containing (file_path, extracted_text)
+        """
+        results = []
+        for file_path in file_paths:
+            try:
+                path = Path(file_path)
+                if path.suffix.lower() == '.pdf':
+                    text = self.process_pdf(file_path, language)
+                else:
+                    text = self.process_image(file_path, language)
+                results.append((str(file_path), text))
+            except Exception as e:
+                results.append((str(file_path), f"Error: {str(e)}"))
+        return results
+    
+    def get_supported_languages(self) -> List[str]:
+        """Get list of supported language codes for PaddleOCR.
+        
+        Returns:
+            List of supported language codes
+        """
+        return [
+            'en', 'ch', 'french', 'german', 'japan', 'korean', 'spanish', 
+            'portuguese', 'russian', 'arabic', 'hindi', 'thai', 'vietnamese',
+            'italian', 'dutch', 'polish', 'turkish', 'indonesian', 'malay',
+            'czech', 'danish', 'finnish', 'norwegian', 'swedish', 'hungarian',
+            'romanian', 'slovenian', 'croatian', 'serbian', 'bulgarian',
+            'ukrainian', 'belarusian', 'macedonian', 'albanian', 'lithuanian',
+            'latvian', 'estonian', 'irish', 'welsh', 'basque', 'catalan',
+            'galician', 'maltese', 'afrikaans', 'swahili', 'amharic', 'hausa',
+            'yoruba', 'zulu', 'xhosa', 'sotho', 'tswana', 'pedi', 'venda',
+            'tsonga', 'ndebele', 'siSwati', 'sesotho', 'setswana', 'sepedi',
+            'tshivenda', 'xitsonga', 'isindebele', 'siSwati'
+        ]

--- a/govscape/govscape/processing/pdf_extraction_stage.py
+++ b/govscape/govscape/processing/pdf_extraction_stage.py
@@ -1,14 +1,34 @@
+# AI modified: 2026-04-16, commit: 4a7a81118a560918e0ea7825dce27f3e5a60a340
 import json
 import os
 from multiprocessing import get_context
+from typing import Optional, Type
 
 import pypdfium2
 
 from ..config import DataModel
+from .ocr import AbstractOCR
 from .processing_stage import ProcessingStage
 
 
-def _convert_single_pdf(data_model, pdf_file):
+def _convert_single_pdf(
+    data_model, 
+    pdf_file, 
+    use_ocr: bool = False,
+    ocr_class: Optional[Type[AbstractOCR]] = None,
+    ocr_config: Optional[dict] = None,
+    language: Optional[str] = None,
+):
+    """Process a single PDF file and extract text and images.
+    
+    Args:
+        data_model: DataModel instance for file path generation
+        pdf_file: Path to the PDF file to process
+        use_ocr: Whether to use OCR for text extraction
+        ocr_class: OCR class to use if use_ocr is True
+        ocr_config: Configuration parameters for the OCR engine
+        language: Language code for OCR
+    """
     pdf_name = os.path.splitext(os.path.basename(pdf_file))[0]
     os.makedirs(data_model.txt_pdf_directory(pdf_name), exist_ok=True)
     os.makedirs(data_model.img_pdf_directory(pdf_name), exist_ok=True)
@@ -30,19 +50,29 @@ def _convert_single_pdf(data_model, pdf_file):
         with open(data_model.metadata_file_path(pdf_name), "w") as json_file:
             json.dump(json_data, json_file, indent=4)
 
-        text = []
         images = []
         for i in range(num_pages):
             page = pdf[i]
-            page_text = page.get_textpage().get_text_bounded()
-            text.append(page_text)
             pil_image = page.render(scale=1.0).to_pil()
             images.append(pil_image)
+        
+        # Extract text either via OCR or directly from PDF
+        if use_ocr and ocr_class is not None:
+            # Use OCR for text extraction
+            ocr_engine = ocr_class(**(ocr_config or {}))
+            page_texts = ocr_engine.process_pdf_per_page(pdf_file, language)
+        else:
+            # Use direct text extraction from PDF
+            page_texts = []
+            for i in range(num_pages):
+                page = pdf[i]
+                page_text = page.get_textpage().get_text_bounded()
+                page_texts.append(page_text)
     except Exception:
         return False
 
-    for page_num, page_text in enumerate(text):
-        if page_text and len(page_text) != 0:
+    for page_num, page_text in enumerate(page_texts):
+        if page_text and len(page_text.strip()) != 0:
             with open(
                 data_model.txt_page_path(pdf_name, page_num), "w", encoding="utf-8"
             ) as text_file:
@@ -55,23 +85,74 @@ def _convert_single_pdf(data_model, pdf_file):
 
 
 class PDFExtractionStage(ProcessingStage):
-    def __init__(self, data_model: DataModel, pdf_files: list[str], cpu_count: int):
+    """Processing stage that extracts text and images from PDFs.
+    
+    This stage can optionally use OCR for text extraction instead of the default
+    direct PDF text extraction. When OCR is enabled, each page is processed using
+    the specified OCR engine and the text is saved per page following the 
+    DATA_MODEL.md naming convention:
+    - {test,dev,prod}-serving/txt/{digest}/{digest}_{pg_no}.txt
+    - {test,dev,prod}-serving/img/{digest}/{digest}_{pg_no}.jpeg
+    - {test,dev,prod}-serving/metadata/{digest}/metadata.json
+    """
+    
+    def __init__(
+        self, 
+        data_model: DataModel, 
+        pdf_files: list[str], 
+        cpu_count: int,
+        use_ocr: bool = False,
+        ocr_class: Optional[Type[AbstractOCR]] = None,
+        ocr_config: Optional[dict] = None,
+        language: Optional[str] = None,
+    ):
+        """Initialize the PDF extraction stage.
+        
+        Args:
+            data_model: DataModel instance for file path generation
+            pdf_files: List of PDF file paths to process
+            cpu_count: Number of CPU cores to use for parallel processing
+            use_ocr: Whether to use OCR for text extraction (default: False)
+            ocr_class: OCR class to use if use_ocr is True (default: None)
+            ocr_config: Configuration parameters for the OCR engine (default: None)
+            language: Language code for OCR (e.g., 'en', 'spa') (default: None)
+        """
         self.data_model = data_model
         self.pdf_files = pdf_files
         self.cpu_count = cpu_count
+        self.use_ocr = use_ocr
+        self.ocr_class = ocr_class
+        self.ocr_config = ocr_config or {}
+        self.language = language
 
     def validate(self) -> None:
+        """Validate that all PDF files exist."""
         missing = [f for f in self.pdf_files if not os.path.isfile(f)]
         if missing:
             raise ValueError(
                 f"{len(missing)} PDF file(s) not found, e.g.: {missing[0]}"
             )
 
-    def run(self):
+    def run(self) -> int:
+        """Run the PDF extraction stage.
+        
+        Returns:
+            Number of successfully processed PDF files
+        """
         ctx = get_context("spawn")
         with ctx.Pool(processes=self.cpu_count) as pool:
             results = pool.starmap(
                 _convert_single_pdf,
-                [(self.data_model, pdf_file) for pdf_file in self.pdf_files],
+                [
+                    (
+                        self.data_model, 
+                        pdf_file,
+                        self.use_ocr,
+                        self.ocr_class,
+                        self.ocr_config,
+                        self.language
+                    )
+                    for pdf_file in self.pdf_files
+                ],
             )
         return sum(results)

--- a/govscape/tests/test_embedding_pipeline.py
+++ b/govscape/tests/test_embedding_pipeline.py
@@ -10,6 +10,7 @@ from govscape.processing import (
     PDFExtractionStage,
     TextEmbeddingStage,
 )
+from govscape.processing.ocr import OCRMyPDF
 from govscape.processing.pdf_extraction_stage import _convert_single_pdf
 
 
@@ -160,3 +161,60 @@ def test_process_pdfs_text_only(sample_pipeline):
         stem = Path(pdf_file).stem
         assert (txt_base / stem).exists()
         assert (img_base / stem).exists()
+
+
+def test_pdf_extraction_stage_with_ocr(sample_pipeline):
+    """Test PDF extraction stage with OCR enabled."""
+    pipeline, pdf_files = sample_pipeline
+    
+    # Test with OCR enabled
+    stage = PDFExtractionStage(
+        data_model=pipeline.data_model,
+        pdf_files=pdf_files,
+        cpu_count=pipeline.cpu_count,
+        use_ocr=True,
+        ocr_class=OCRMyPDF,
+        ocr_config={'language': 'eng'},
+        language='eng'
+    )
+    
+    # This should not raise any validation errors
+    stage.validate()
+    
+    # Run the stage - this may fail if OCRMyPDF dependencies are not installed,
+    # but the important thing is that the integration works
+    try:
+        result = stage.run()
+        assert isinstance(result, int)
+        assert result >= 0
+    except ImportError:
+        # OCRMyPDF dependencies may not be installed in test environment
+        # This is expected and doesn't indicate a problem with our integration
+        pass
+
+
+def test_pdf_extraction_stage_without_ocr(sample_pipeline):
+    """Test PDF extraction stage without OCR (default behavior)."""
+    pipeline, pdf_files = sample_pipeline
+    
+    # Test without OCR (default behavior)
+    stage = PDFExtractionStage(
+        data_model=pipeline.data_model,
+        pdf_files=pdf_files,
+        cpu_count=pipeline.cpu_count,
+        use_ocr=False
+    )
+    
+    # This should not raise any validation errors
+    stage.validate()
+    
+    # Run the stage
+    result = stage.run()
+    assert isinstance(result, int)
+    assert result >= 0
+    
+    # Verify that text files were created
+    txt_base = Path(pipeline.data_model.txt_directory)
+    for pdf_file in pdf_files:
+        stem = Path(pdf_file).stem
+        assert (txt_base / stem).exists()


### PR DESCRIPTION
This commit is working to solve the problem of not using OCRs to break down the pages of the files into text files from the image pdfs. I have made an OCR folder in the processing folder which has an OCR abstract class as well as files for each of the four OCRs I am planning on testing. Each should process a file page by page and label the subsequent file generated as per the naming convention listing in the DATA_MODEL.md file. I then have a simple test file to go with this. One thing I do want to note, govscape is running on python 3.11.14, I could not find this version on the official Python website to download. Therefore testing this code is not a possibility at the moment. I have also incorporated the OCR processing into the related pipline files.