### PR TITLE
S3DataLoader Bucket Prefixes + Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,15 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
+      - name: Add poetry to path
+        run: |
+          export PATH=$PATH:/opt/poetry/bin
       - name: Install packages
         run: |
-          /opt/poetry/bin/poetry install
+          poetry install
       - name: Run tests
         run: |
-          /opt/poetry/bin/poetry run pytest tests
+          poetry run pytest tests
       - uses: codecov/codecov-action@v5
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,11 @@ jobs:
           export PATH=$PATH:/opt/poetry/bin
       - name: Install packages
         run: |
+          export PATH=$PATH:/opt/poetry/bin
           poetry install
       - name: Run tests
         run: |
+          export PATH=$PATH:/opt/poetry/bin
           poetry run pytest tests
       - uses: codecov/codecov-action@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,12 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
-      - name: Add poetry to path
-        run: |
-          export PATH=$PATH:/opt/poetry/bin
+      - name: Add poetry to PATH
+        run: echo "/opt/poetry/bin" >> "$GITHUB_PATH"
       - name: Install packages
-        run: |
-          export PATH=$PATH:/opt/poetry/bin
-          poetry install
+        run: poetry install
       - name: Run tests
-        run: |
-          export PATH=$PATH:/opt/poetry/bin
-          poetry run pytest tests
+        run: poetry run pytest tests
       - uses: codecov/codecov-action@v5
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,14 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
-      - name: Add poetry to PATH
-        run: echo "/opt/poetry/bin" >> "$GITHUB_PATH"
       - name: Install packages
-        run: poetry install
+        run: |
+          export PATH=$PATH:/opt/poetry/bin
+          poetry install
       - name: Run tests
-        run: poetry run pytest tests
+        run: |
+          export PATH=$PATH:/opt/poetry/bin
+          poetry run pytest tests
       - uses: codecov/codecov-action@v5
 
 on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ it's clear for the reviewer which files were AI generated.
 This is a **mandatory requirement**. Include it with every modification to any file. If
 there are existing AI comments, add yours right after them.
 
+## Running Commands
+- In this directory, all python commands should be run using poetry, e.g. 'poetry run pytest...',  'poetry run python3 ...', 'poetry add [package-name]'.
+
 ## Coding style
 
 - Don't explain every line with a separate comment, use comments for complex chunks of code,

--- a/CONTRIBUTOR.md
+++ b/CONTRIBUTOR.md
@@ -140,7 +140,7 @@ You can pull this data from the S3 bucket by using:
 
 ```
 poetry run python scripts/data_prep/download_sample_pdfs.py \
-    --bucket_name us-west-2.opendata.source.coop/govscape/eota-pdf-archive/eot-pdf-archive \
+    --bucket_name us-west-2.opendata.source.coop/govscape/eota-pdf-archive/ \
     --local_base_dir data/s3_mock \
     --num_pdfs 500
 ```
@@ -152,7 +152,7 @@ from EPA domains:
 
 ```
 poetry run python scripts/data_prep/download_sample_pdfs.py \
-    --bucket_name us-west-2.opendata.source.coop/govscape/eota-pdf-archive/eot-pdf-archive \
+    --bucket_name us-west-2.opendata.source.coop/govscape/eota-pdf-archive/ \
     --local_base_dir data/s3_mock \
     --num_pdfs 500 \
     --url_filter epa.gov

--- a/CONTRIBUTOR.md
+++ b/CONTRIBUTOR.md
@@ -140,7 +140,7 @@ You can pull this data from the S3 bucket by using:
 
 ```
 poetry run python scripts/data_prep/download_sample_pdfs.py \
-    --bucket_name eot-pdf-archive \
+    --bucket_name us-west-2.opendata.source.coop/govscape/eota-pdf-archive/eot-pdf-archive \
     --local_base_dir data/s3_mock \
     --num_pdfs 500
 ```
@@ -152,7 +152,7 @@ from EPA domains:
 
 ```
 poetry run python scripts/data_prep/download_sample_pdfs.py \
-    --bucket_name eot-pdf-archive \
+    --bucket_name us-west-2.opendata.source.coop/govscape/eota-pdf-archive/eot-pdf-archive \
     --local_base_dir data/s3_mock \
     --num_pdfs 500 \
     --url_filter epa.gov

--- a/benchmarks/vector_index_benchmark_realistic.py
+++ b/benchmarks/vector_index_benchmark_realistic.py
@@ -155,6 +155,7 @@ def generate_embeddings(num_embeddings: int, dim: int, seed: int) -> np.ndarray:
         print("Downloaded batch of embeddings, total so far:", len(embeddings))
     if len(embeddings) < num_embeddings:
         raise ValueError(f"Expected {num_embeddings} embeddings, got {len(embeddings)}")
+    iterator.close()
     return np.array(embeddings[:num_embeddings], dtype=np.float32)
 
 

--- a/govscape/data_loader.py
+++ b/govscape/data_loader.py
@@ -514,7 +514,6 @@ class RemoteDirectoryIterator:
         """Shut down the cached multiprocessing pool, if any."""
         if self._mp_pool is not None:
             self._mp_pool.terminate()
-            self._mp_pool.join()
             self._mp_pool = None
 
     def __enter__(self) -> Self:

--- a/govscape/data_loader.py
+++ b/govscape/data_loader.py
@@ -180,13 +180,23 @@ class DataLoader(ABC):
 
 
 class S3DataLoader(DataLoader):
+    """DataLoader implementation for AWS S3 using boto3. For compliance
+    with source.coop, the bucket_name parameter may include an optional
+    prefix, e.g. "my-bucket/path/to/data", which will be prepended to
+    all prefixes/object keys.
+    """
+
     def __init__(
         self,
         bucket_name: str,
         config: Config,
         s3_client: S3Client | None = None,
     ) -> None:
-        self.bucket_name = bucket_name
+        if bucket_name.__contains__("/"):
+            self.bucket_name, self.base_prefix = bucket_name.split("/", 1)
+        else:
+            self.bucket_name = bucket_name
+            self.base_prefix = ""
         self.s3: S3Client = s3_client or boto3.client("s3", config=config)
 
     def list_objects(
@@ -197,7 +207,7 @@ class S3DataLoader(DataLoader):
     ) -> ListResult:
         kwargs = {
             "Bucket": self.bucket_name,
-            "Prefix": prefix,
+            "Prefix": self.base_prefix + prefix,
             "MaxKeys": max_keys,
         }
         if continuation_token:
@@ -226,7 +236,9 @@ class S3DataLoader(DataLoader):
         self, remote_path: str, local_path: str, decompress: bool = False
     ) -> list[str]:
         os.makedirs(os.path.dirname(local_path), exist_ok=True)
-        self.s3.download_file(self.bucket_name, remote_path, local_path)
+        self.s3.download_file(
+            self.bucket_name, self.base_prefix + remote_path, local_path
+        )
         if decompress and local_path.endswith(".tar.gz"):
             return self._decompress_tar_gz(local_path)
         return [local_path]
@@ -243,17 +255,21 @@ class S3DataLoader(DataLoader):
                 "--log",
                 "error",
                 "sync",
-                f"s3://{self.bucket_name}/{normalized_prefix}",
+                f"s3://{self.bucket_name}/{normalized_prefix}*",
                 normalized_local_dir,
             ],
             check=True,
         )
 
     def upload_file(self, local_path: str, remote_path: str) -> None:
-        self.s3.upload_file(local_path, self.bucket_name, remote_path)
+        self.s3.upload_file(
+            local_path, self.bucket_name, self.base_prefix + remote_path
+        )
 
     def upload_bytes(self, data: bytes, remote_path: str) -> None:
-        self.s3.put_object(Bucket=self.bucket_name, Key=remote_path, Body=data)
+        self.s3.put_object(
+            Bucket=self.bucket_name, Key=self.base_prefix + remote_path, Body=data
+        )
 
     def upload_directory(
         self,
@@ -284,22 +300,27 @@ class S3DataLoader(DataLoader):
     def copy_object(self, source_path: str, dest_path: str) -> None:
         self.s3.copy_object(
             Bucket=self.bucket_name,
-            CopySource=f"/{self.bucket_name}/{source_path}",
-            Key=dest_path,
+            CopySource=f"/{self.bucket_name}/{self.base_prefix + source_path}",
+            Key=self.base_prefix + dest_path,
         )
 
     def delete_object(self, remote_path: str) -> None:
-        self.s3.delete_object(Bucket=self.bucket_name, Key=remote_path)
+        self.s3.delete_object(
+            Bucket=self.bucket_name, Key=self.base_prefix + remote_path
+        )
 
     def exists(self, remote_path: str) -> bool:
         try:
-            self.s3.head_object(Bucket=self.bucket_name, Key=remote_path)
+            self.s3.head_object(
+                Bucket=self.bucket_name, Key=self.base_prefix + remote_path
+            )
             return True
         except ClientError:
             return False
 
     def to_uri(self, remote_path: str) -> str:
-        return f"https://{self.bucket_name}.s3.amazonaws.com/{remote_path}"
+        return f"https://{self.bucket_name}.s3.amazonaws.com/\
+            {self.base_prefix + remote_path}"
 
 
 class LocalDataLoader(DataLoader):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,8 @@ build-backend = "poetry.core.masonry.api"
 dev = [
     "types-requests (>=2.32.4.20260107,<3.0.0.0)",
     "pandas-stubs (>=3.0.0.260204,<4.0.0.0)",
-    "types-flask-cors (>=6.0.0.20250809,<7.0.0.0)"
+    "types-flask-cors (>=6.0.0.20250809,<7.0.0.0)",
+    "moto[server] (>=5.0.0,<6.0.0)"
 ]
 
 [tool.ruff]

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,7 +6,6 @@ filterwarnings =
     # The combination of pylucene 10.0.0 and python 3.11.14 likes to emit warnings.
     # These warnings do not affect functionality, but they do pollute the test output.
     ignore:builtin type .* has no __module__ attribute:DeprecationWarning
-testpaths =
-    govscape/tests
+testpaths = tests
 junit_family=xunit2
 xfail_strict=true

--- a/scripts/data_prep/download_sample_pdfs.py
+++ b/scripts/data_prep/download_sample_pdfs.py
@@ -80,6 +80,9 @@ def main():
             break
         remote_key = f"{REMOTE_PDF_DIR}{digest}.pdf"
         if not data_loader.exists(remote_key):
+            logging.warning(
+                f"Warning: PDF for digest {remote_key} not found in bucket, skipping"
+            )
             continue
         local_path = os.path.join(local_pdf_dir, f"{digest}.pdf")
         data_loader.download_file(remote_key, local_path)

--- a/scripts/indexing/generate_index_embedding.py
+++ b/scripts/indexing/generate_index_embedding.py
@@ -259,4 +259,7 @@ if __name__ == "__main__":
     def main():
         batched_file_download(BATCH_SIZE)
 
-    main()
+    try:
+        main()
+    finally:
+        remote_iter.close()

--- a/scripts/indexing/generate_index_keyword.py
+++ b/scripts/indexing/generate_index_keyword.py
@@ -215,4 +215,7 @@ if __name__ == "__main__":
     def main():
         batched_file_download(BATCH_SIZE)
 
-    main()
+    try:
+        main()
+    finally:
+        remote_iter.close()

--- a/scripts/indexing/generate_index_metadata.py
+++ b/scripts/indexing/generate_index_metadata.py
@@ -189,6 +189,8 @@ def main():
         local_dm.index_metadata_directory, remote_dm.index_metadata_directory
     )
 
+    remote_iter.close()
+
 
 def _read_metadata_row(filepath):
     try:

--- a/scripts/pipeline/run_embedding_pipeline.py
+++ b/scripts/pipeline/run_embedding_pipeline.py
@@ -296,6 +296,8 @@ def main():
         # Upload the performance JSON to S3
         data_loader.upload_file(local_perf_path, remote_perf_path)
 
+    remote_pdf_iter.close()
+
     # After all batches are processed, clean up the directories
     if os.path.exists(local_dm.data_dir):
         shutil.rmtree(local_dm.data_dir)

--- a/scripts/serving/run_gunicorn.py
+++ b/scripts/serving/run_gunicorn.py
@@ -43,19 +43,21 @@ def download_indices(args):
         (remote_dm.index_img_pg_directory, local_dm.index_img_pg_directory),
         (remote_dm.index_metadata_directory, local_dm.index_metadata_directory),
     ]:
-        remote_iter = RemoteDirectoryIterator(
+        with RemoteDirectoryIterator(
             data_loader,
             remote_dir,
             REMOTE_CHECKPOINT_PATH,
             LOCAL_CHECKPOINT_PATH,
             local_dir,
-        )
-        finished = False
-        while not finished:
-            downloaded_files = remote_iter.download_batch()
-            if len(downloaded_files) == 0:
-                finished = True
-                print(f"Finished downloading indices from {remote_dir} to {local_dir}")
+        ) as remote_iter:
+            finished = False
+            while not finished:
+                downloaded_files = remote_iter.download_batch()
+                if len(downloaded_files) == 0:
+                    finished = True
+                    print(
+                        f"Finished downloading indices from {remote_dir} to {local_dir}"
+                    )
 
     remote_blacklist = remote_dm.blacklist_file
     local_blacklist = local_dm.blacklist_file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
+import os
 import shutil
+from collections.abc import Iterator
 
 import pytest
 
@@ -7,6 +9,63 @@ dirs_to_remove = [
     "tests/test_data/small/embeddings",
     "tests/test_data/small/images",
 ]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def aws_credentials() -> Iterator[None]:
+    """Provide dummy AWS credentials so boto3 and s5cmd can sign requests.
+
+    These point at nothing real; all S3 traffic is served by the moto mock
+    server (see ``moto_server``).
+    """
+    fake_env = {
+        "AWS_ACCESS_KEY_ID": "testing",
+        "AWS_SECRET_ACCESS_KEY": "testing",
+        "AWS_SESSION_TOKEN": "testing",
+        "AWS_DEFAULT_REGION": "us-east-1",
+    }
+    previous = {key: os.environ.get(key) for key in fake_env}
+    os.environ.update(fake_env)
+    yield
+    for key, value in previous.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+@pytest.fixture(scope="session")
+def moto_server(aws_credentials: None) -> Iterator[str]:
+    """Start an in-process mock S3 HTTP server for the test session.
+
+    Running moto in *server* mode (rather than the in-process ``mock_aws``
+    decorator) is required because ``S3DataLoader`` reaches S3 through the
+    ``s5cmd`` subprocess and through forked multiprocessing workers, neither of
+    which an in-process monkeypatch can intercept. Pointing ``S3_ENDPOINT_URL``
+    (read by s5cmd) and ``AWS_ENDPOINT_URL`` (read by botocore, inherited by
+    forked workers) at the server redirects all of them to the mock.
+    """
+    from moto.server import ThreadedMotoServer
+
+    server = ThreadedMotoServer(port=0)
+    server.start()
+    _, port = server.get_host_and_port()
+    endpoint = f"http://127.0.0.1:{port}"
+
+    previous = {
+        key: os.environ.get(key) for key in ("AWS_ENDPOINT_URL", "S3_ENDPOINT_URL")
+    }
+    os.environ["AWS_ENDPOINT_URL"] = endpoint
+    os.environ["S3_ENDPOINT_URL"] = endpoint
+    try:
+        yield endpoint
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        server.stop()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_local_data_loader.py
+++ b/tests/test_local_data_loader.py
@@ -1,10 +1,19 @@
 import math
 import os
+import uuid
 from pathlib import Path
 
 import pytest
 
-from govscape.data_loader import LocalDataLoader, RemoteDirectoryIterator
+import boto3
+from botocore.config import Config
+
+from govscape.data_loader import (
+    DataLoader,
+    LocalDataLoader,
+    RemoteDirectoryIterator,
+    S3DataLoader,
+)
 
 
 def _touch(path: Path) -> None:
@@ -12,26 +21,53 @@ def _touch(path: Path) -> None:
     path.write_text("x")
 
 
+@pytest.fixture(params=["local", "s3"])
+def loader(request: pytest.FixtureRequest, tmp_path: Path) -> DataLoader:
+    """Provide a DataLoader for each backend so a single test covers both.
+
+    The ``local`` variant stores objects under ``tmp_path``. The ``s3`` variant
+    talks to the session-scoped moto mock server (see ``tests/conftest.py``);
+    each test gets a freshly created, uniquely named bucket for isolation.
+    """
+    if request.param == "local":
+        return LocalDataLoader(base_dir=str(tmp_path / "data"))
+
+    endpoint = request.getfixturevalue("moto_server")
+    bucket = f"test-bucket-{uuid.uuid4().hex[:12]}"
+    config = Config(max_pool_connections=10)
+    client = boto3.client("s3", endpoint_url=endpoint, config=config)
+    client.create_bucket(Bucket=bucket)
+    return S3DataLoader(bucket_name=bucket, config=config, s3_client=client)
+
+
+def _remote_basenames(loader: DataLoader, prefix: str) -> list[str]:
+    """Return the sorted basenames of objects stored under ``prefix``.
+
+    Uses the backend-agnostic ``list_objects`` interface so the same assertion
+    works for both the local and S3 loaders.
+    """
+    keys = loader.list_objects(prefix, max_keys=100000).keys
+    return sorted(os.path.basename(key) for key in keys)
+
+
 @pytest.mark.parametrize("use_multiprocessing", [False, True])
-def test_local_data_loader_continuation_token(
-    tmp_path: Path, use_multiprocessing: bool
+def test_data_loader_continuation_token(
+    loader: DataLoader, tmp_path: Path, use_multiprocessing: bool
 ) -> None:
-    base_dir = tmp_path / "data"
-    checkpoint_path = tmp_path / "checkpoint.json"
+    checkpoint_path = "checkpoint.json"
     local_checkpoint_path = tmp_path / "local_checkpoint.json"
 
     download_dir = tmp_path / "download"
 
-    # Create 5 files under a prefix directory
+    # Create 5 files under a prefix.
     prefix = "files"
     for i in range(5):
-        _touch(base_dir / prefix / f"file_{i}.txt")
+        loader.upload_bytes(b"x", f"{prefix}/file_{i}.txt")
 
-    loader = LocalDataLoader(base_dir=str(base_dir))
     remote_iter = RemoteDirectoryIterator(
         loader,
         prefix,
-        str(checkpoint_path),
+        checkpoint_path,
         str(local_checkpoint_path),
         local_dir=str(download_dir),
         use_multiprocessing=use_multiprocessing,
@@ -51,7 +87,7 @@ def test_local_data_loader_continuation_token(
     remote_iter2 = RemoteDirectoryIterator(
         loader,
         prefix,
-        str(checkpoint_path),
+        checkpoint_path,
         str(local_checkpoint_path),
         local_dir=str(download_dir),
         use_multiprocessing=use_multiprocessing,
@@ -64,8 +100,7 @@ def test_local_data_loader_continuation_token(
     assert len(result4) == 0
 
 
-def test_upload_directory_compressed(tmp_path: Path) -> None:
-    base_dir = tmp_path / "data"
+def test_upload_directory_compressed(loader: DataLoader, tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     remote_prefix = "uploaded"
 
@@ -74,13 +109,11 @@ def test_upload_directory_compressed(tmp_path: Path) -> None:
     for i in range(num_files):
         _touch(source_dir / f"subdir_{i // 100}" / f"file_{i}.txt")
 
-    loader = LocalDataLoader(base_dir=str(base_dir))
     loader.upload_directory(
         str(source_dir), remote_prefix, compress=True, chunk_size=chunk_size
     )
 
-    dest_dir = base_dir / remote_prefix
-    uploaded_files = sorted(dest_dir.iterdir())
+    uploaded_names = _remote_basenames(loader, remote_prefix)
 
     # Build the expected chunk names using the same hash logic as the
     # implementation: collect all files sorted, split into chunks, and hash
@@ -99,13 +132,12 @@ def test_upload_directory_compressed(tmp_path: Path) -> None:
     expected_names.sort()
 
     expected_chunks = math.ceil(num_files / chunk_size)
-    assert len(uploaded_files) == expected_chunks
-    assert all(f.name.endswith(".tar.gz") for f in uploaded_files)
-    assert [f.name for f in uploaded_files] == expected_names
+    assert len(uploaded_names) == expected_chunks
+    assert all(name.endswith(".tar.gz") for name in uploaded_names)
+    assert uploaded_names == expected_names
 
 
-def test_download_file_decompress(tmp_path: Path) -> None:
-    base_dir = tmp_path / "data"
+def test_download_file_decompress(loader: DataLoader, tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     download_dir = tmp_path / "download"
     remote_prefix = "uploaded"
@@ -117,18 +149,15 @@ def test_download_file_decompress(tmp_path: Path) -> None:
         for i in range(num_files):
             _touch(source_dir / subdir / f"file_{i}.txt")
 
-    loader = LocalDataLoader(base_dir=str(base_dir))
     loader.upload_directory(
         str(source_dir), remote_prefix, compress=True, chunk_size=1000
     )
 
     # There should be exactly one .tar.gz chunk.
-    dest_dir = base_dir / remote_prefix
-    tar_files = list(dest_dir.iterdir())
-    assert len(tar_files) == 1
-    tar_name = tar_files[0].name
-
-    remote_tar_path = f"{remote_prefix}/{tar_name}"
+    tar_keys = loader.list_objects(remote_prefix, max_keys=100000).keys
+    assert len(tar_keys) == 1
+    remote_tar_path = tar_keys[0]
+    tar_name = os.path.basename(remote_tar_path)
     local_tar_path = str(download_dir / tar_name)
 
     loader.download_file(remote_tar_path, local_tar_path, decompress=True)
@@ -147,8 +176,7 @@ def test_download_file_decompress(tmp_path: Path) -> None:
         assert extracted == expected
 
 
-def test_download_directory(tmp_path: Path) -> None:
-    base_dir = tmp_path / "data"
+def test_download_directory(loader: DataLoader, tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     download_dir = tmp_path / "download"
     remote_prefix = "uploaded"
@@ -157,7 +185,6 @@ def test_download_directory(tmp_path: Path) -> None:
     _touch(source_dir / "subdir_b" / "file_2.txt")
     _touch(source_dir / "file_3.txt")
 
-    loader = LocalDataLoader(base_dir=str(base_dir))
     loader.upload_directory(str(source_dir), remote_prefix)
     loader.download_directory(remote_prefix, str(download_dir))
 
@@ -168,7 +195,7 @@ def test_download_directory(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("use_multiprocessing", [False, True])
 def test_remote_directory_iterator_compressed(
-    tmp_path: Path, use_multiprocessing: bool
+    loader: DataLoader, tmp_path: Path, use_multiprocessing: bool
 ) -> None:
     """Round-trip test: upload with compression, iterate with RemoteDirectoryIterator.
 
@@ -176,11 +203,10 @@ def test_remote_directory_iterator_compressed(
     chunks, returns the correct extracted file paths, respects filter_fn,
     handles multiple chunks via batching, and works with checkpointing.
     """
-    base_dir = tmp_path / "data"
     download_dir = tmp_path / "download"
     source_dir = tmp_path / "source"
     remote_prefix = "compressed_files"
-    checkpoint_path = os.path.join(str(base_dir), "checkpoints", "checkpoint.json")
+    checkpoint_path = "checkpoints/checkpoint.json"
     local_checkpoint_path = str(tmp_path / "local_checkpoint.json")
 
     # Create 15 .npy files and 5 .txt files across subdirectories so we can
@@ -196,15 +222,13 @@ def test_remote_directory_iterator_compressed(
         _touch(source_dir / subdir / f"notes_{i}.txt")
     npy_files_created.sort()
 
-    loader = LocalDataLoader(base_dir=str(base_dir))
-
     # Upload with small chunk_size to force multiple .tar.gz archives.
     loader.upload_directory(str(source_dir), remote_prefix, compress=True, chunk_size=8)
 
     # Verify multiple chunks were created.
-    dest_dir = base_dir / remote_prefix
-    tar_files = [f for f in dest_dir.iterdir() if f.name.endswith(".tar.gz")]
-    assert len(tar_files) >= 2, "Expected multiple compressed chunks"
+    tar_names = _remote_basenames(loader, remote_prefix)
+    assert all(name.endswith(".tar.gz") for name in tar_names)
+    assert len(tar_names) >= 2, "Expected multiple compressed chunks"
 
     # --- Batch 1: download first batch with a filter for .npy files only ---
     remote_iter = RemoteDirectoryIterator(

--- a/tests/test_local_data_loader.py
+++ b/tests/test_local_data_loader.py
@@ -83,6 +83,8 @@ def test_data_loader_continuation_token(
     assert len(result2) == 2
     remote_iter.save_checkpoint()
 
+    remote_iter.close()
+
     # New iter should resume from checkpoint
     remote_iter2 = RemoteDirectoryIterator(
         loader,
@@ -98,6 +100,8 @@ def test_data_loader_continuation_token(
     # No more files to download
     result4 = remote_iter2.download_batch(max_keys=2)
     assert len(result4) == 0
+
+    remote_iter2.close()
 
 
 def test_upload_directory_compressed(loader: DataLoader, tmp_path: Path) -> None:
@@ -268,6 +272,8 @@ def test_remote_directory_iterator_compressed(
 
     # --- Verify checkpointing: a new iterator should have nothing left ---
     remote_iter.save_checkpoint()
+    remote_iter.close()
+
     remote_iter2 = RemoteDirectoryIterator(
         loader,
         remote_prefix,
@@ -279,3 +285,4 @@ def test_remote_directory_iterator_compressed(
     batch2 = remote_iter2.download_batch(max_keys=4)
     # The first iterator consumed all pages, so the second should be empty.
     assert len(batch2) == 0
+    remote_iter2.close()


### PR DESCRIPTION
This PR adds the ability to point the S3DataLoader at a particular prefix of a bucket rather than at the base of a bucket, i.e. "us-west-2.opendata.source.coop/govscape/eota-pdf-archive/".