### PR TITLE
Threading branch

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,29 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef",
+      "integrity": "sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef"
+    },
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.7",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:a3e43ff91b9f5f6bd2c14bd510d43e5e698f1266dc41027ba4e04e7e45be607a",
+      "integrity": "sha256:a3e43ff91b9f5f6bd2c14bd510d43e5e698f1266dc41027ba4e04e7e45be607a"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/govscape/processing/ocr_processing_stage.py
+++ b/govscape/processing/ocr_processing_stage.py
@@ -1,8 +1,11 @@
 """OCR Processing Stage - Extracts text from PDF pages using OCR engines."""
 
+# AI modified: 2026-06-30T00:00:00Z 9572ec457fa5bc348c0a58148e220cc1ff48e98f
+
 import contextlib
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor
 
 try:
     import cv2
@@ -45,7 +48,11 @@ class OCRProcessingStage(ProcessingStage):
 
     def __init__(self, data_model: DataModel, ocr_type: str = "easyocr", **ocr_kwargs):
         self.data_model = data_model
-        self.ocr_engine = _build_ocr_engine(ocr_type, **ocr_kwargs)
+        self.ocr_type = ocr_type
+        self.ocr_kwargs = dict(ocr_kwargs)
+        self.batch_size = self.ocr_kwargs.pop("batch_size", 1000)
+        self.max_workers = self.ocr_kwargs.pop("max_workers", None)
+        self.ocr_engine = _build_ocr_engine(ocr_type, **self.ocr_kwargs)
         self.logger = logging.getLogger(__name__)
 
     def validate(self) -> None:
@@ -67,6 +74,9 @@ class OCRProcessingStage(ProcessingStage):
             raise ValueError(f"OCR engine validation failed: {e}") from e
 
     def run(self):
+        self.run_single_threaded()
+
+    def run_single_threaded(self):
         os.makedirs(self.data_model.txt_directory, exist_ok=True)
 
         error_count = 0
@@ -109,10 +119,9 @@ class OCRProcessingStage(ProcessingStage):
             )
             return
 
-        _BATCH_SIZE = 1000
         all_texts: list[str] = []
-        for batch_start in range(0, len(all_images), _BATCH_SIZE):
-            batch = all_images[batch_start : batch_start + _BATCH_SIZE]
+        for batch_start in range(0, len(all_images), self.batch_size):
+            batch = all_images[batch_start : batch_start + self.batch_size]
             try:
                 all_texts.extend(self.ocr_engine.extract_text(batch))
             except Exception as e:
@@ -133,6 +142,90 @@ class OCRProcessingStage(ProcessingStage):
             f"OCR processing complete. Processed: {processed_count}, "
             f"Errors: {error_count}",
         )
+
+    def run_parallel(self):
+        os.makedirs(self.data_model.txt_directory, exist_ok=True)
+
+        error_count = 0
+        all_images: list = []
+        all_metadata: list[tuple[str, int]] = []
+        engine_name = self.ocr_engine.__class__.__name__.lower()
+
+        for digest_dir in os.scandir(self.data_model.image_directory):
+            if not digest_dir.is_dir():
+                continue
+
+            digest = digest_dir.name
+            os.makedirs(self.data_model.txt_pdf_directory(digest), exist_ok=True)
+
+            page_files = sorted(
+                [f for f in os.listdir(digest_dir.path) if f.endswith(".jpeg")],
+            )
+
+            for page_file in page_files:
+                image_path = os.path.join(digest_dir.path, page_file)
+                try:
+                    image = cv2.imread(image_path)
+                    if image is None:
+                        self.logger.warning(f"Failed to read image: {image_path}")
+                        error_count += 1
+                        continue
+                    if "paddle" not in engine_name:
+                        with contextlib.suppress(Exception):
+                            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+                    page_num = int(page_file.split("_")[-1].replace(".jpeg", ""))
+                    all_images.append(image)
+                    all_metadata.append((digest, page_num))
+                except Exception as e:
+                    self.logger.error(f"Error loading {image_path}: {e}")
+                    error_count += 1
+
+        if not all_images:
+            self.logger.info(
+                "OCR processing complete. Processed: 0, Errors: %d", error_count
+            )
+            return
+
+        batch_specs = [
+            (
+                all_images[start : start + self.batch_size],
+                all_metadata[start : start + self.batch_size],
+            )
+            for start in range(0, len(all_images), self.batch_size)
+        ]
+
+        worker_count = self.max_workers or max(1, min(4, os.cpu_count() or 1))
+        all_texts: list[str] = []
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            for batch_texts, batch_errors in executor.map(
+                self._process_batch_in_thread, batch_specs
+            ):
+                all_texts.extend(batch_texts)
+                error_count += batch_errors
+
+        processed_count = 0
+        for (digest, page_num), text in zip(all_metadata, all_texts, strict=True):
+            if self._write_page_text(digest, page_num, text):
+                processed_count += 1
+            else:
+                error_count += 1
+
+        self.logger.info(
+            f"OCR processing complete. Processed: {processed_count}, "
+            f"Errors: {error_count}",
+        )
+
+    def _process_batch_in_thread(self, batch_spec):
+        batch_images, _batch_metadata = batch_spec
+        ocr_engine = _build_ocr_engine(self.ocr_type, **self.ocr_kwargs)
+        try:
+            texts = ocr_engine.extract_text(batch_images)
+            return texts, 0
+        except Exception as e:
+            self.logger.error(
+                f"OCR failed for batch with {len(batch_images)} images: {e}"
+            )
+            return [""] * len(batch_images), len(batch_images)
 
     def _write_page_text(self, digest: str, page_num: int, text: str) -> bool:
         try:

--- a/govscape/processing/ocr_processing_stage.py
+++ b/govscape/processing/ocr_processing_stage.py
@@ -1,7 +1,5 @@
 """OCR Processing Stage - Extracts text from PDF pages using OCR engines."""
 
-# AI modified: 2026-06-30T00:00:00Z 9572ec457fa5bc348c0a58148e220cc1ff48e98f
-
 import contextlib
 import logging
 import os
@@ -77,6 +75,7 @@ class OCRProcessingStage(ProcessingStage):
         self.run_single_threaded()
 
     def run_single_threaded(self):
+        self.validate()
         os.makedirs(self.data_model.txt_directory, exist_ok=True)
 
         error_count = 0
@@ -144,6 +143,7 @@ class OCRProcessingStage(ProcessingStage):
         )
 
     def run_parallel(self):
+        self.validate()
         os.makedirs(self.data_model.txt_directory, exist_ok=True)
 
         error_count = 0

--- a/scripts/run_ocr_comparison.py
+++ b/scripts/run_ocr_comparison.py
@@ -1,0 +1,79 @@
+"""Run PDF extraction and OCR comparison on the sample test PDFs."""
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+from PIL import Image
+
+from govscape.config import DataModel
+from govscape.processing.ocr_processing_stage import OCRProcessingStage
+from govscape.processing.pdf_extraction_stage import PDFExtractionStage
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    data_dir = repo_root / "tests" / "test_data" / "small"
+    output_dir = repo_root / "tmp_ocr_compare"
+    output_dir.mkdir(exist_ok=True)
+
+    data_model = DataModel(str(output_dir))
+    pdf_files = sorted((data_dir / "PDFs").glob("*.pdf"))
+
+    class FakeCV2:
+        @staticmethod
+        def imread(path):
+            image = Image.open(path).convert("RGB")
+            return np.array(image)
+
+        @staticmethod
+        def cvtColor(image, _code):
+            return image
+
+    import govscape.processing.ocr_processing_stage as ocr_stage_module
+
+    ocr_stage_module.cv2 = FakeCV2
+    ocr_stage_module.CV2_AVAILABLE = True
+
+    if not pdf_files:
+        raise FileNotFoundError(f"No PDF files found in {data_dir / 'PDFs'}")
+
+    print(f"Converting {len(pdf_files)} PDFs to images...")
+    extract_stage = PDFExtractionStage(
+        data_model=data_model,
+        pdf_files=[str(path) for path in pdf_files],
+        cpu_count=1,
+    )
+    extract_stage.run()
+
+    stage = OCRProcessingStage(
+        data_model=data_model,
+        ocr_type="easyocr",
+        batch_size=1,
+        max_workers=2,
+    )
+
+    def fake_extract_text(images):
+        return [f"ocr-result-for-{len(images)}-image(s)" for _ in images]
+
+    with (
+        patch.object(stage.ocr_engine, "validate", return_value=None),
+        patch.object(stage.ocr_engine, "extract_text", side_effect=fake_extract_text),
+    ):
+        print("Running single-threaded OCR...")
+        single_start = time.perf_counter()
+        stage.run_single_threaded()
+        single_elapsed = time.perf_counter() - single_start
+
+        print("Running parallel OCR...")
+        parallel_start = time.perf_counter()
+        stage.run_parallel()
+        parallel_elapsed = time.perf_counter() - parallel_start
+
+    print(f"single-threaded={single_elapsed:.6f}s parallel={parallel_elapsed:.6f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,7 +1,10 @@
 """Tests for OCR implementations and OCRProcessingStage."""
 
+# AI modified: 2026-06-30T00:00:00Z 9572ec457fa5bc348c0a58148e220cc1ff48e98f
+
 import os
 import tempfile
+from time import perf_counter
 from unittest.mock import patch
 
 import pytest
@@ -104,7 +107,7 @@ def test_ocr_processing_stage_writes_txt(
     """
     pytest.importorskip("cv2")
 
-    tmpdir, data_model = temp_data_dir
+    _, data_model = temp_data_dir
 
     # Map impl_class to ocr_type string expected by OCRProcessingStage
     impl_to_type = {
@@ -147,3 +150,60 @@ def test_ocr_processing_stage_writes_txt(
     with open(txt_file, encoding="utf-8") as f:
         content = f.read()
         assert content == mocked_text
+
+
+def test_single_threaded_and_parallel_paths_compare_outputs(temp_data_dir):
+    """The parallel path should produce the same OCR output as the
+    single-threaded path."""
+    pytest.importorskip("cv2")
+
+    _, data_model = temp_data_dir
+    import cv2
+
+    digest = "compareparallel123456"
+    img_dir = os.path.join(data_model.image_directory, digest)
+    os.makedirs(img_dir, exist_ok=True)
+
+    for page_num in range(2):
+        img_path = os.path.join(img_dir, f"{digest}_{page_num}.jpeg")
+        img = _create_test_image(f"PAGE {page_num}")
+        cv2.imwrite(img_path, cv2.cvtColor(img, cv2.COLOR_RGB2BGR))
+
+    stage = OCRProcessingStage(
+        data_model=data_model,
+        ocr_type="easyocr",
+        batch_size=1,
+        max_workers=2,
+    )
+
+    def fake_extract_text(images):
+        return [f"ocr-result-for-{len(images)}-image(s)" for _ in images]
+
+    with (
+        patch.object(stage.ocr_engine, "validate", return_value=None),
+        patch.object(stage.ocr_engine, "extract_text", side_effect=fake_extract_text),
+        patch(
+            "govscape.processing.ocr_processing_stage._build_ocr_engine",
+            return_value=stage.ocr_engine,
+        ),
+    ):
+        stage.validate()
+
+        single_start = perf_counter()
+        stage.run_single_threaded()
+        single_elapsed = perf_counter() - single_start
+
+        parallel_start = perf_counter()
+        stage.run_parallel()
+        parallel_elapsed = perf_counter() - parallel_start
+
+    print(f"single-threaded={single_elapsed:.6f}s parallel={parallel_elapsed:.6f}s")
+
+    for page_num in range(2):
+        txt_file = data_model.txt_page_path(digest, page_num)
+        with open(txt_file, encoding="utf-8") as f:
+            content = f.read()
+        assert content == "ocr-result-for-1-image(s)"
+
+    assert single_elapsed >= 0
+    assert parallel_elapsed >= 0

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,7 +1,5 @@
 """Tests for OCR implementations and OCRProcessingStage."""
 
-# AI modified: 2026-06-30T00:00:00Z 9572ec457fa5bc348c0a58148e220cc1ff48e98f
-
 import os
 import tempfile
 from time import perf_counter


### PR DESCRIPTION
This pull request has the edits to run ocr_processing_stage with multiple threads, also known as batching. It still contains the single processing program in a method. This is so that I can compare the run times between the single processing and the batch processing with a new script. This script runs the PDF Extraction Phase, then OCR Processing Single Processing and then Batch Processing. It will then compare the two run times. This will have to be run separately for each OCR model.