### PR TITLE
Hybrid search threading sequential

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,29 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/devcontainers/features/aws-cli@sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef",
+      "integrity": "sha256:1f93c8315b7a6d76982ebb2269f8b0d50413fc0f965c032edf4aee0caceb73ef"
+    },
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.8",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2",
+      "integrity": "sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/benchmarks/hybrid_keyword_vector_search_benchmark.py
+++ b/benchmarks/hybrid_keyword_vector_search_benchmark.py
@@ -1,0 +1,332 @@
+"""Benchmark hybrid search performance for parallel vs sequential execution.
+
+This script builds a synthetic FAISS/vector index, a keyword index, and a
+metadata index. It then compares timing for:
+- existing textual hybrid search
+- existing keyword hybrid search
+- new combined keyword+vector hybrid search (sequential)
+- new combined keyword+vector hybrid search (parallel)
+
+Example:
+    poetry run python benchmarks/hybrid_keyword_vector_search_benchmark.py \
+        --documents 1000 --pages-per-doc 4 --queries 20 --k 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import shutil
+import statistics
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from govscape.indexing import (
+    FAISSIndex,
+    SQLiteKeywordIndex,
+    SQLiteMetadataIndex,
+)
+from govscape.indexing.hybrid import (
+    HybridKeywordMetadataIndex,
+    HybridKeywordVectorMetadataIndex,
+    HybridVectorMetadataIndex,
+)
+from govscape.query import EqualityPredicate, Predicate
+
+
+@dataclass
+class BenchmarkResult:
+    name: str
+    average_ms: float
+
+
+def _parse_csv_ints(value: str) -> list[int]:
+    return [int(v.strip()) for v in value.split(",") if v.strip()]
+
+
+def _build_documents(
+    documents: int,
+    pages_per_doc: int,
+    dim: int,
+    seed: int,
+):
+    rng = np.random.default_rng(seed)
+    pdf_names = [f"doc_{idx:06d}.pdf" for idx in range(documents)]
+    base_vectors = rng.normal(size=(documents, dim)).astype(np.float32)
+
+    texts: list[str] = []
+    digests: list[str] = []
+    pages: list[str] = []
+    vectors: list[np.ndarray] = []
+    sub_domains: list[str] = []
+
+    for idx, pdf_name in enumerate(pdf_names):
+        sub_domain = "target.gov" if idx % 10 == 0 else "other.gov"
+        sub_domains.append(sub_domain)
+
+        for page in range(pages_per_doc):
+            digests.append(pdf_name)
+            pages.append(str(page))
+            vectors.append(base_vectors[idx] + rng.normal(scale=0.05, size=(dim,)))
+            texts.append(
+                f"{pdf_name} page {page} \n{sub_domain} policy resilience data"
+            )
+
+    return pdf_names, digests, pages, texts, np.vstack(vectors), sub_domains
+
+
+def _build_records(
+    pdf_names: list[str], pages_per_doc: int, sub_domains: list[str]
+) -> list[dict]:
+    records: list[dict] = []
+    for idx, pdf_name in enumerate(pdf_names):
+        records.append(
+            {
+                "crawl_url": f"https://{sub_domains[idx]}/report/{pdf_name}",
+                "crawl_date": "20240101",
+                "digest": pdf_name,
+                "pretty_name": pdf_name,
+                "sub_domain": sub_domains[idx],
+                "page_count": pages_per_doc,
+            }
+        )
+    return records
+
+
+def _prepare_metadata_index(
+    index_dir: Path,
+    records: list[dict],
+    vector_store_key: str,
+    vectors: np.ndarray,
+    digests: list[str],
+    pages: list[str],
+) -> SQLiteMetadataIndex:
+    if index_dir.exists():
+        shutil.rmtree(index_dir)
+    index_dir.mkdir(parents=True, exist_ok=True)
+
+    metadata_index = SQLiteMetadataIndex(index_dir.as_posix())
+    metadata_index.build_index()
+    metadata_index.add_batch(records)
+    metadata_index.upsert_vectors(vector_store_key, vectors, digests, pages)
+    metadata_index.save_index()
+    metadata_index.load_index()
+    return metadata_index
+
+
+def _prepare_keyword_index(
+    index_dir: Path,
+    texts: list[str],
+    digests: list[str],
+    pages: list[str],
+) -> SQLiteKeywordIndex:
+    if index_dir.exists():
+        shutil.rmtree(index_dir)
+    index_dir.mkdir(parents=True, exist_ok=True)
+
+    keyword_index = SQLiteKeywordIndex(index_dir.as_posix())
+    keyword_index.build_index()
+    keyword_index.add_batch(texts, digests, pages)
+    keyword_index.load_index()
+    return keyword_index
+
+
+def _prepare_faiss_index(
+    index_dir: Path,
+    vectors: np.ndarray,
+    digests: list[str],
+    pages: list[str],
+) -> FAISSIndex:
+    if index_dir.exists():
+        shutil.rmtree(index_dir)
+    index_dir.mkdir(parents=True, exist_ok=True)
+
+    faiss_index = FAISSIndex(index_dir.as_posix())
+    faiss_index.add_batch(vectors, digests, pages)
+    return faiss_index
+
+
+def _measure_search_time(
+    search_fn,
+    query_items,
+) -> BenchmarkResult:
+    times: list[float] = []
+    for query in query_items:
+        start = time.perf_counter()
+        search_fn(*query)
+        times.append(time.perf_counter() - start)
+    return BenchmarkResult("", statistics.mean(times) * 1000)
+
+
+def run_benchmark(
+    documents: int,
+    pages_per_doc: int,
+    dim: int,
+    queries: int,
+    k: int,
+    work_dir: Path,
+    seed: int,
+) -> list[BenchmarkResult]:
+    pdf_names, digests, pages, texts, vectors, sub_domains = _build_documents(
+        documents, pages_per_doc, dim, seed
+    )
+    records = _build_records(pdf_names, pages_per_doc, sub_domains)
+
+    metadata_index = _prepare_metadata_index(
+        work_dir / "metadata",
+        records,
+        "text",
+        vectors,
+        digests,
+        pages,
+    )
+    keyword_index = _prepare_keyword_index(work_dir / "keyword", texts, digests, pages)
+    faiss_index = _prepare_faiss_index(work_dir / "faiss", vectors, digests, pages)
+
+    text_hybrid = HybridVectorMetadataIndex(
+        vector_index=faiss_index,
+        metadata_index=metadata_index,
+        vector_store_key="text",
+    )
+    keyword_hybrid = HybridKeywordMetadataIndex(
+        keyword_index=keyword_index,
+        metadata_index=metadata_index,
+    )
+    combined_hybrid = HybridKeywordVectorMetadataIndex(
+        vector_hybrid_index=text_hybrid,
+        keyword_hybrid_index=keyword_hybrid,
+    )
+
+    rng = random.Random(seed + 1)
+    query_indices = [rng.randrange(len(vectors)) for _ in range(queries)]
+    query_texts = [texts[idx] for idx in query_indices]
+    query_vectors = [vectors[idx] for idx in query_indices]
+
+    predicates: list[Predicate] = [EqualityPredicate("sub_domain", "target.gov")]
+
+    results: list[BenchmarkResult] = []
+
+    search_pairs = [
+        (q_vec, q_txt) for q_vec, q_txt in zip(query_vectors, query_texts, strict=True)
+    ]
+
+    results.append(
+        BenchmarkResult(
+            name="textual_hybrid",
+            average_ms=_measure_search_time(
+                lambda q_vec, q_txt: text_hybrid.search(q_vec, predicates, k),
+                search_pairs,
+            ).average_ms,
+        )
+    )
+    results.append(
+        BenchmarkResult(
+            name="keyword_hybrid",
+            average_ms=_measure_search_time(
+                lambda q_vec, q_txt: keyword_hybrid.search(q_txt, predicates, k),
+                search_pairs,
+            ).average_ms,
+        )
+    )
+    results.append(
+        BenchmarkResult(
+            name="combined_hybrid_sequential",
+            average_ms=_measure_search_time(
+                lambda q_vec, q_txt: combined_hybrid.search(
+                    q_vec, q_txt, predicates, k, parallel=False
+                ),
+                search_pairs,
+            ).average_ms,
+        )
+    )
+    results.append(
+        BenchmarkResult(
+            name="combined_hybrid_parallel",
+            average_ms=_measure_search_time(
+                lambda q_vec, q_txt: combined_hybrid.search(
+                    q_vec, q_txt, predicates, k, parallel=True
+                ),
+                search_pairs,
+            ).average_ms,
+        )
+    )
+
+    return results
+
+
+def format_results(rows: list[BenchmarkResult]) -> str:
+    header = f"{'Search Mode':<28} {'Avg Latency (ms)':>18}"
+    lines = [header, "-" * len(header)]
+    lines.extend([f"{row.name:<28} {row.average_ms:>18.3f}" for row in rows])
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark hybrid search performance."  # pragma: no cover
+    )
+    parser.add_argument(
+        "--documents",
+        type=int,
+        default=1000,
+        help="Number of distinct PDF documents to generate.",
+    )
+    parser.add_argument(
+        "--pages-per-doc",
+        type=int,
+        default=4,
+        help="Number of pages per PDF document.",
+    )
+    parser.add_argument(
+        "--dim",
+        type=int,
+        default=384,
+        help="Embedding dimensionality.",
+    )
+    parser.add_argument(
+        "--queries",
+        type=int,
+        default=20,
+        help="Number of queries to benchmark.",
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        default=20,
+        help="Result count to request from each search.",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=Path("/tmp/govscape_hybrid_search_bench"),
+        help="Working directory for temporary index artifacts.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=7,
+        help="Random seed for synthetic data generation.",
+    )
+    args = parser.parse_args()
+
+    if args.work_dir.exists():
+        shutil.rmtree(args.work_dir)
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = run_benchmark(
+        documents=args.documents,
+        pages_per_doc=args.pages_per_doc,
+        dim=args.dim,
+        queries=args.queries,
+        k=args.k,
+        work_dir=args.work_dir,
+        seed=args.seed,
+    )
+    print(format_results(rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/govscape/api/endpoints/search.py
+++ b/govscape/api/endpoints/search.py
@@ -13,6 +13,9 @@ search_input = ns.model(
         "query": fields.String(required=True, description="Search query text"),
         "search_type": fields.String(required=True, description="Search query text"),
         "filters": fields.Raw(description="Filters to apply to the search"),
+        "weights": fields.Raw(
+            description=("Optional per-search weights for hybrid searches")
+        ),
         "page": fields.Integer(description="Page number for pagination", default=1),
     },
 )
@@ -120,6 +123,7 @@ class Search(Resource):
             search_type=search_type,
             predicates=predicates,
             page=data.get("page", 1),
+            weights=data.get("weights", None),
         )
 
         server = current_app.server

--- a/govscape/indexing/__init__.py
+++ b/govscape/indexing/__init__.py
@@ -1,7 +1,9 @@
+from .base import AbstractIndex
 from .hybrid import (
     STRATEGY_POSTFILTER,
     STRATEGY_PREFILTER,
     AbstractHybridMetadataIndex,
+    HybridIndex,
     HybridKeywordMetadataIndex,
     HybridKeywordVectorMetadataIndex,
     HybridTextVisualKeywordIndex,
@@ -29,11 +31,13 @@ __all__ = [
     "STRATEGY_POSTFILTER",
     "STRATEGY_PREFILTER",
     "AbstractHybridMetadataIndex",
+    "AbstractIndex",
     "AbstractKeywordIndex",
     "AbstractMetadataIndex",
     "AbstractVectorIndex",
     "DuckDBMetadataIndex",
     "FAISSIndex",
+    "HybridIndex",
     "HybridKeywordMetadataIndex",
     "HybridKeywordVectorMetadataIndex",
     "HybridTextVisualKeywordIndex",

--- a/govscape/indexing/__init__.py
+++ b/govscape/indexing/__init__.py
@@ -4,6 +4,7 @@ from .hybrid import (
     AbstractHybridMetadataIndex,
     HybridKeywordMetadataIndex,
     HybridKeywordVectorMetadataIndex,
+    HybridTextVisualKeywordIndex,
     HybridVectorMetadataIndex,
 )
 from .keyword import (
@@ -35,6 +36,7 @@ __all__ = [
     "FAISSIndex",
     "HybridKeywordMetadataIndex",
     "HybridKeywordVectorMetadataIndex",
+    "HybridTextVisualKeywordIndex",
     "HybridVectorMetadataIndex",
     "LanceDBKeywordIndex",
     "LanceDBVectorIndex",

--- a/govscape/indexing/__init__.py
+++ b/govscape/indexing/__init__.py
@@ -3,6 +3,7 @@ from .hybrid import (
     STRATEGY_PREFILTER,
     AbstractHybridMetadataIndex,
     HybridKeywordMetadataIndex,
+    HybridKeywordVectorMetadataIndex,
     HybridVectorMetadataIndex,
 )
 from .keyword import (
@@ -33,6 +34,7 @@ __all__ = [
     "DuckDBMetadataIndex",
     "FAISSIndex",
     "HybridKeywordMetadataIndex",
+    "HybridKeywordVectorMetadataIndex",
     "HybridVectorMetadataIndex",
     "LanceDBKeywordIndex",
     "LanceDBVectorIndex",

--- a/govscape/indexing/base.py
+++ b/govscape/indexing/base.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class AbstractIndex(ABC):
+    """Common contract for indexes that can provide ranked search results."""
+
+    @abstractmethod
+    def search(self, query: Any, k: int):
+        """Return ranked results for a query."""
+
+    @abstractmethod
+    def total_entries(self) -> int:
+        """Return the number of searchable entries."""

--- a/govscape/indexing/hybrid.py
+++ b/govscape/indexing/hybrid.py
@@ -1,8 +1,8 @@
-# AI modified
 from __future__ import annotations
 
 import math
 from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
 import numpy as np
@@ -307,3 +307,190 @@ class HybridKeywordMetadataIndex(AbstractHybridMetadataIndex):
             current_k = min(self._index_total_entries(), current_k * 2)
 
         return filtered_rows[:target_results], metadata, current_k
+
+
+class HybridKeywordVectorMetadataIndex:
+    def __init__(
+        self,
+        vector_hybrid_index: HybridVectorMetadataIndex,
+        keyword_hybrid_index: HybridKeywordMetadataIndex,
+        vector_weight: float = 1.0,
+        keyword_weight: float = 1.0,
+    ):
+        self.vector_hybrid_index = vector_hybrid_index
+        self.keyword_hybrid_index = keyword_hybrid_index
+        self.vector_weight = vector_weight
+        self.keyword_weight = keyword_weight
+
+    @staticmethod
+    def _rank_score(rank: int) -> float:
+        return 1.0 / (rank + 1)
+
+    @staticmethod
+    def _merge_metadata(
+        vector_metadata: dict[str, list[dict]],
+        keyword_metadata: dict[str, list[dict]],
+    ) -> dict[str, list[dict]]:
+        merged = {**vector_metadata}
+        for digest, entries in keyword_metadata.items():
+            if digest in merged:
+                merged[digest] = merged[digest] + entries
+            else:
+                merged[digest] = list(entries)
+        return merged
+
+    def _combine_rows(
+        self,
+        vector_rows: list[tuple[float, str, str]],
+        keyword_rows: list[tuple[float, str, str]],
+        target_results: int,
+    ) -> list[tuple[float, str, str]]:
+        combined: dict[str, dict] = {}
+
+        for rank, row in enumerate(vector_rows):
+            distance, digest, page = row
+            combined[digest] = {
+                "row": row,
+                "vector_rank": rank,
+                "keyword_rank": None,
+            }
+
+        for rank, row in enumerate(keyword_rows):
+            distance, digest, page = row
+            entry = combined.get(digest)
+            if entry is None:
+                combined[digest] = {
+                    "row": row,
+                    "vector_rank": None,
+                    "keyword_rank": rank,
+                }
+            else:
+                entry["keyword_rank"] = rank
+                vector_rank = entry["vector_rank"]
+                if vector_rank is None or self._rank_score(rank) > self._rank_score(
+                    vector_rank
+                ):
+                    entry["row"] = row
+
+        scored_rows: list[tuple[float, tuple[float, str, str]]] = []
+        for entry in combined.values():
+            score = 0.0
+            if entry["vector_rank"] is not None:
+                score += self.vector_weight * self._rank_score(entry["vector_rank"])
+            if entry["keyword_rank"] is not None:
+                score += self.keyword_weight * self._rank_score(entry["keyword_rank"])
+            scored_rows.append((score, entry["row"]))
+
+        scored_rows.sort(key=lambda item: (-item[0], item[1][0], item[1][1]))
+        return [row for _, row in scored_rows[:target_results]]
+
+    def _search_components(
+        self,
+        query_embedding,
+        query_text,
+        predicates,
+        target_results,
+        blacklist,
+        parallel: bool = True,
+    ):
+        search_k_vector = min(
+            self.vector_hybrid_index._index_total_entries(),
+            max(target_results * 3, 20),
+        )
+        search_k_keyword = min(
+            self.keyword_hybrid_index._index_total_entries(),
+            max(target_results * 3, 20),
+        )
+
+        if parallel:
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                vector_future = executor.submit(
+                    self.vector_hybrid_index.search,
+                    query_embedding,
+                    predicates,
+                    search_k_vector,
+                    blacklist,
+                )
+                keyword_future = executor.submit(
+                    self.keyword_hybrid_index.search,
+                    query_text,
+                    predicates,
+                    search_k_keyword,
+                    blacklist,
+                )
+                vector_rows, vector_metadata, vector_state = vector_future.result()
+                keyword_rows, keyword_metadata, keyword_state = keyword_future.result()
+        else:
+            vector_rows, vector_metadata, vector_state = (
+                self.vector_hybrid_index.search(
+                    query_embedding,
+                    predicates,
+                    search_k_vector,
+                    blacklist,
+                )
+            )
+            keyword_rows, keyword_metadata, keyword_state = (
+                self.keyword_hybrid_index.search(
+                    query_text,
+                    predicates,
+                    search_k_keyword,
+                    blacklist,
+                )
+            )
+
+        return (
+            vector_rows,
+            vector_metadata,
+            vector_state,
+            keyword_rows,
+            keyword_metadata,
+            keyword_state,
+        )
+
+    def search(
+        self,
+        query_embedding,
+        query_text,
+        predicates,
+        target_results,
+        blacklist=None,
+        parallel: bool = True,
+    ):
+        if blacklist is None:
+            blacklist = set()
+
+        (
+            vector_rows,
+            vector_metadata,
+            vector_state,
+            keyword_rows,
+            keyword_metadata,
+            keyword_state,
+        ) = self._search_components(
+            query_embedding,
+            query_text,
+            predicates,
+            target_results,
+            blacklist,
+            parallel=parallel,
+        )
+
+        combined_rows = self._combine_rows(
+            vector_rows,
+            keyword_rows,
+            target_results,
+        )
+        combined_metadata = self._merge_metadata(vector_metadata, keyword_metadata)
+        combined_state = HybridSearchState(
+            strategy="combined",
+            current_k=max(vector_state.current_k, keyword_state.current_k),
+            estimated_selectivity=max(
+                vector_state.estimated_selectivity,
+                keyword_state.estimated_selectivity,
+            ),
+            prefilter_cost=(vector_state.prefilter_cost + keyword_state.prefilter_cost),
+            postfilter_cost=(
+                vector_state.postfilter_cost + keyword_state.postfilter_cost
+            ),
+        )
+        return combined_rows, combined_metadata, combined_state

--- a/govscape/indexing/hybrid.py
+++ b/govscape/indexing/hybrid.py
@@ -494,3 +494,248 @@ class HybridKeywordVectorMetadataIndex:
             ),
         )
         return combined_rows, combined_metadata, combined_state
+
+
+class HybridTextVisualKeywordIndex:
+    def __init__(
+        self,
+        text_vector_hybrid_index: HybridVectorMetadataIndex,
+        visual_vector_hybrid_index: HybridVectorMetadataIndex,
+        keyword_hybrid_index: HybridKeywordMetadataIndex,
+    ):
+        self.text_vector_hybrid_index = text_vector_hybrid_index
+        self.visual_vector_hybrid_index = visual_vector_hybrid_index
+        self.keyword_hybrid_index = keyword_hybrid_index
+
+    @staticmethod
+    def _rank_score(rank: int) -> float:
+        return 1.0 / (rank + 1)
+
+    @staticmethod
+    def _merge_metadata(
+        *metadatas: dict[str, list[dict]],
+    ) -> dict[str, list[dict]]:
+        merged: dict[str, list[dict]] = {}
+        for md in metadatas:
+            for digest, entries in md.items():
+                if digest in merged:
+                    merged[digest] = merged[digest] + entries
+                else:
+                    merged[digest] = list(entries)
+        return merged
+
+    def _combine_rows(
+        self,
+        text_rows: list[tuple[float, str, str]],
+        visual_rows: list[tuple[float, str, str]],
+        keyword_rows: list[tuple[float, str, str]],
+        target_results: int,
+        weights: dict | None = None,
+    ) -> list[tuple[float, str, str]]:
+        if weights is None:
+            weights = {"textual": 1.0, "visual": 1.0, "keyword": 1.0}
+
+        t_weight = float(weights.get("textual", weights.get("text", 0.0) or 0.0))
+        v_weight = float(weights.get("visual", 0.0))
+        k_weight = float(weights.get("keyword", 0.0))
+
+        combined: dict[str, dict] = {}
+
+        for rank, row in enumerate(text_rows):
+            distance, digest, page = row
+            combined[digest] = {
+                "row": row,
+                "text_rank": rank,
+                "visual_rank": None,
+                "keyword_rank": None,
+            }
+
+        for rank, row in enumerate(visual_rows):
+            distance, digest, page = row
+            entry = combined.get(digest)
+            if entry is None:
+                combined[digest] = {
+                    "row": row,
+                    "text_rank": None,
+                    "visual_rank": rank,
+                    "keyword_rank": None,
+                }
+            else:
+                entry["visual_rank"] = rank
+
+        for rank, row in enumerate(keyword_rows):
+            distance, digest, page = row
+            entry = combined.get(digest)
+            if entry is None:
+                combined[digest] = {
+                    "row": row,
+                    "text_rank": None,
+                    "visual_rank": None,
+                    "keyword_rank": rank,
+                }
+            else:
+                entry["keyword_rank"] = rank
+                # Prefer a row from higher-scoring component for tie-breaking
+                text_rank = entry.get("text_rank")
+                visual_rank = entry.get("visual_rank")
+                if entry.get("row") is None or (
+                    text_rank is None and visual_rank is None
+                ):
+                    entry["row"] = row
+
+        scored_rows: list[tuple[float, tuple[float, str, str]]] = []
+        for entry in combined.values():
+            score = 0.0
+            if entry.get("text_rank") is not None:
+                score += t_weight * self._rank_score(entry["text_rank"])
+            if entry.get("visual_rank") is not None:
+                score += v_weight * self._rank_score(entry["visual_rank"])
+            if entry.get("keyword_rank") is not None:
+                score += k_weight * self._rank_score(entry["keyword_rank"])
+            scored_rows.append((score, entry["row"]))
+
+        scored_rows.sort(key=lambda item: (-item[0], item[1][0], item[1][1]))
+        return [row for _, row in scored_rows[:target_results]]
+
+    def _search_components(
+        self,
+        query_embedding,
+        query_text,
+        predicates,
+        target_results,
+        blacklist,
+        parallel: bool = True,
+    ):
+        search_k_vector = min(
+            self.text_vector_hybrid_index._index_total_entries(),
+            max(target_results * 3, 20),
+        )
+        search_k_visual = min(
+            self.visual_vector_hybrid_index._index_total_entries(),
+            max(target_results * 3, 20),
+        )
+        search_k_keyword = min(
+            self.keyword_hybrid_index._index_total_entries(),
+            max(target_results * 3, 20),
+        )
+
+        if parallel:
+            with ThreadPoolExecutor(max_workers=3) as executor:
+                text_future = executor.submit(
+                    self.text_vector_hybrid_index.search,
+                    query_embedding,
+                    predicates,
+                    search_k_vector,
+                    blacklist,
+                )
+                visual_future = executor.submit(
+                    self.visual_vector_hybrid_index.search,
+                    query_embedding,
+                    predicates,
+                    search_k_visual,
+                    blacklist,
+                )
+                keyword_future = executor.submit(
+                    self.keyword_hybrid_index.search,
+                    query_text,
+                    predicates,
+                    search_k_keyword,
+                )
+                text_rows, text_metadata, text_state = text_future.result()
+                visual_rows, visual_metadata, visual_state = visual_future.result()
+                keyword_rows, keyword_metadata, keyword_state = keyword_future.result()
+        else:
+            text_rows, text_metadata, text_state = self.text_vector_hybrid_index.search(
+                query_embedding, predicates, search_k_vector, blacklist
+            )
+            visual_rows, visual_metadata, visual_state = (
+                self.visual_vector_hybrid_index.search(
+                    query_embedding, predicates, search_k_visual, blacklist
+                )
+            )
+            keyword_rows, keyword_metadata, keyword_state = (
+                self.keyword_hybrid_index.search(
+                    query_text, predicates, search_k_keyword
+                )
+            )
+
+        return (
+            text_rows,
+            text_metadata,
+            text_state,
+            visual_rows,
+            visual_metadata,
+            visual_state,
+            keyword_rows,
+            keyword_metadata,
+            keyword_state,
+        )
+
+    def search(
+        self,
+        query_embedding,
+        query_text,
+        predicates,
+        target_results,
+        blacklist=None,
+        parallel: bool = True,
+        weights: dict | None = None,
+    ):
+        if blacklist is None:
+            blacklist = set()
+
+        (
+            text_rows,
+            text_metadata,
+            text_state,
+            visual_rows,
+            visual_metadata,
+            visual_state,
+            keyword_rows,
+            keyword_metadata,
+            keyword_state,
+        ) = self._search_components(
+            query_embedding,
+            query_text,
+            predicates,
+            target_results,
+            blacklist,
+            parallel=parallel,
+        )
+
+        combined_rows = self._combine_rows(
+            text_rows,
+            visual_rows,
+            keyword_rows,
+            target_results,
+            weights=weights,
+        )
+        combined_metadata = self._merge_metadata(
+            text_metadata,
+            visual_metadata,
+            keyword_metadata,
+        )
+        combined_state = HybridSearchState(
+            strategy="combined",
+            current_k=max(
+                text_state.current_k,
+                visual_state.current_k,
+                keyword_state.current_k,
+            ),
+            estimated_selectivity=max(
+                text_state.estimated_selectivity,
+                visual_state.estimated_selectivity,
+                keyword_state.estimated_selectivity,
+            ),
+            prefilter_cost=(
+                text_state.prefilter_cost
+                + visual_state.prefilter_cost
+                + keyword_state.prefilter_cost
+            ),
+            postfilter_cost=(
+                text_state.postfilter_cost
+                + visual_state.postfilter_cost
+                + keyword_state.postfilter_cost
+            ),
+        )
+        return combined_rows, combined_metadata, combined_state

--- a/govscape/indexing/hybrid.py
+++ b/govscape/indexing/hybrid.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from .base import AbstractIndex
 from .keyword import AbstractKeywordIndex
 from .metadata import AbstractMetadataIndex
 from .vector import AbstractVectorIndex
@@ -24,7 +25,7 @@ class HybridSearchState:
     postfilter_cost: float
 
 
-class AbstractHybridMetadataIndex(ABC):
+class AbstractHybridMetadataIndex(AbstractIndex, ABC):
     def __init__(self, metadata_index: AbstractMetadataIndex):
         self.metadata_index = metadata_index
 
@@ -81,6 +82,9 @@ class AbstractHybridMetadataIndex(ABC):
     @abstractmethod
     def _index_total_entries(self) -> int:
         pass
+
+    def total_entries(self) -> int:
+        return self._index_total_entries()
 
     @abstractmethod
     def _run_prefilter(
@@ -309,433 +313,186 @@ class HybridKeywordMetadataIndex(AbstractHybridMetadataIndex):
         return filtered_rows[:target_results], metadata, current_k
 
 
-class HybridKeywordVectorMetadataIndex:
+class HybridIndex(AbstractIndex):
+    """Combine any number of metadata-aware indexes using weighted ranks."""
+
     def __init__(
         self,
-        vector_hybrid_index: HybridVectorMetadataIndex,
-        keyword_hybrid_index: HybridKeywordMetadataIndex,
+        indices: list[AbstractIndex],
+        weights: list[float] | None = None,
+    ):
+        if not indices:
+            raise ValueError("HybridIndex requires at least one index")
+        if weights is not None and len(weights) != len(indices):
+            raise ValueError("HybridIndex weights must match the number of indices")
+        self.indices = indices
+        self.weights = weights or [1.0] * len(indices)
+
+    def total_entries(self) -> int:
+        return sum(index.total_entries() for index in self.indices)
+
+    def _index_total_entries(self) -> int:
+        return max(index.total_entries() for index in self.indices)
+
+    @staticmethod
+    def _rank_score(rank: int) -> float:
+        return 1.0 / (rank + 1)
+
+    @staticmethod
+    def _merge_metadata(*metadatas: dict[str, list[dict]]) -> dict[str, list[dict]]:
+        merged: dict[str, list[dict]] = {}
+        for metadata in metadatas:
+            for digest, entries in metadata.items():
+                merged.setdefault(digest, []).extend(entries)
+        return merged
+
+    def _combine_rows(
+        self,
+        component_rows: list[list[tuple[float, str, str]]],
+        target_results: int,
+        weights: list[float],
+    ) -> list[tuple[float, str, str]]:
+        combined: dict[str, dict] = {}
+
+        for component_rank, rows in enumerate(component_rows):
+            for rank, row in enumerate(rows):
+                digest = row[1]
+                entry = combined.setdefault(
+                    digest,
+                    {"row": row, "ranks": [None] * len(component_rows)},
+                )
+                entry["ranks"][component_rank] = rank
+
+        scored_rows: list[tuple[float, tuple[float, str, str]]] = []
+        for entry in combined.values():
+            score = sum(
+                weight * self._rank_score(rank)
+                for weight, rank in zip(weights, entry["ranks"], strict=False)
+                if rank is not None
+            )
+            scored_rows.append((score, entry["row"]))
+
+        scored_rows.sort(key=lambda item: (-item[0], item[1][0], item[1][1]))
+        return [row for _, row in scored_rows[:target_results]]
+
+    def search(
+        self,
+        queries,
+        predicates,
+        target_results,
+        blacklist=None,
+        parallel: bool = True,
+        weights: list[float] | None = None,
+    ):
+        if blacklist is None:
+            blacklist = set()
+        if len(queries) != len(self.indices):
+            raise ValueError("HybridIndex queries must match the number of indices")
+        weights = weights or self.weights
+        search_futures = []
+        search_k = max(target_results * 3, 20)
+        if parallel:
+            with ThreadPoolExecutor(max_workers=len(self.indices)) as executor:
+                for index, query in zip(self.indices, queries, strict=True):
+                    k = min(index.total_entries(), search_k)
+                    search_futures.append(
+                        executor.submit(
+                            index.search,
+                            query,
+                            predicates,
+                            k,
+                            blacklist,
+                        )
+                    )
+                component_results = [future.result() for future in search_futures]
+        else:
+            component_results = [
+                index.search(
+                    query,
+                    predicates,
+                    min(index.total_entries(), search_k),
+                    blacklist,
+                )
+                for index, query in zip(self.indices, queries, strict=True)
+            ]
+
+        component_rows = [result[0] for result in component_results]
+        combined_rows = self._combine_rows(component_rows, target_results, weights)
+        combined_metadata = self._merge_metadata(
+            *(result[1] for result in component_results)
+        )
+        combined_state = HybridSearchState(
+            strategy="combined",
+            current_k=max(result[2].current_k for result in component_results),
+            estimated_selectivity=max(
+                result[2].estimated_selectivity for result in component_results
+            ),
+            prefilter_cost=sum(
+                result[2].prefilter_cost for result in component_results
+            ),
+            postfilter_cost=sum(
+                result[2].postfilter_cost for result in component_results
+            ),
+        )
+        return combined_rows, combined_metadata, combined_state
+
+
+class HybridKeywordVectorMetadataIndex(HybridIndex):
+    """Compatibility wrapper for the former keyword-text hybrid."""
+
+    def __init__(
+        self,
+        vector_hybrid_index: AbstractIndex,
+        keyword_hybrid_index: AbstractIndex,
         vector_weight: float = 1.0,
         keyword_weight: float = 1.0,
     ):
-        self.vector_hybrid_index = vector_hybrid_index
-        self.keyword_hybrid_index = keyword_hybrid_index
-        self.vector_weight = vector_weight
-        self.keyword_weight = keyword_weight
-
-    @staticmethod
-    def _rank_score(rank: int) -> float:
-        return 1.0 / (rank + 1)
-
-    @staticmethod
-    def _merge_metadata(
-        vector_metadata: dict[str, list[dict]],
-        keyword_metadata: dict[str, list[dict]],
-    ) -> dict[str, list[dict]]:
-        merged = {**vector_metadata}
-        for digest, entries in keyword_metadata.items():
-            if digest in merged:
-                merged[digest] = merged[digest] + entries
-            else:
-                merged[digest] = list(entries)
-        return merged
-
-    def _combine_rows(
-        self,
-        vector_rows: list[tuple[float, str, str]],
-        keyword_rows: list[tuple[float, str, str]],
-        target_results: int,
-    ) -> list[tuple[float, str, str]]:
-        combined: dict[str, dict] = {}
-
-        for rank, row in enumerate(vector_rows):
-            distance, digest, page = row
-            combined[digest] = {
-                "row": row,
-                "vector_rank": rank,
-                "keyword_rank": None,
-            }
-
-        for rank, row in enumerate(keyword_rows):
-            distance, digest, page = row
-            entry = combined.get(digest)
-            if entry is None:
-                combined[digest] = {
-                    "row": row,
-                    "vector_rank": None,
-                    "keyword_rank": rank,
-                }
-            else:
-                entry["keyword_rank"] = rank
-                vector_rank = entry["vector_rank"]
-                if vector_rank is None or self._rank_score(rank) > self._rank_score(
-                    vector_rank
-                ):
-                    entry["row"] = row
-
-        scored_rows: list[tuple[float, tuple[float, str, str]]] = []
-        for entry in combined.values():
-            score = 0.0
-            if entry["vector_rank"] is not None:
-                score += self.vector_weight * self._rank_score(entry["vector_rank"])
-            if entry["keyword_rank"] is not None:
-                score += self.keyword_weight * self._rank_score(entry["keyword_rank"])
-            scored_rows.append((score, entry["row"]))
-
-        scored_rows.sort(key=lambda item: (-item[0], item[1][0], item[1][1]))
-        return [row for _, row in scored_rows[:target_results]]
-
-    def _search_components(
-        self,
-        query_embedding,
-        query_text,
-        predicates,
-        target_results,
-        blacklist,
-        parallel: bool = True,
-    ):
-        search_k_vector = min(
-            self.vector_hybrid_index._index_total_entries(),
-            max(target_results * 3, 20),
-        )
-        search_k_keyword = min(
-            self.keyword_hybrid_index._index_total_entries(),
-            max(target_results * 3, 20),
-        )
-
-        if parallel:
-            with ThreadPoolExecutor(max_workers=2) as executor:
-                vector_future = executor.submit(
-                    self.vector_hybrid_index.search,
-                    query_embedding,
-                    predicates,
-                    search_k_vector,
-                    blacklist,
-                )
-                keyword_future = executor.submit(
-                    self.keyword_hybrid_index.search,
-                    query_text,
-                    predicates,
-                    search_k_keyword,
-                    blacklist,
-                )
-                vector_rows, vector_metadata, vector_state = vector_future.result()
-                keyword_rows, keyword_metadata, keyword_state = keyword_future.result()
-        else:
-            vector_rows, vector_metadata, vector_state = (
-                self.vector_hybrid_index.search(
-                    query_embedding,
-                    predicates,
-                    search_k_vector,
-                    blacklist,
-                )
-            )
-            keyword_rows, keyword_metadata, keyword_state = (
-                self.keyword_hybrid_index.search(
-                    query_text,
-                    predicates,
-                    search_k_keyword,
-                    blacklist,
-                )
-            )
-
-        return (
-            vector_rows,
-            vector_metadata,
-            vector_state,
-            keyword_rows,
-            keyword_metadata,
-            keyword_state,
+        super().__init__(
+            [vector_hybrid_index, keyword_hybrid_index],
+            [vector_weight, keyword_weight],
         )
 
     def search(
         self,
         query_embedding,
-        query_text,
-        predicates,
-        target_results,
+        query_text=None,
+        predicates=None,
+        target_results=None,
         blacklist=None,
-        parallel: bool = True,
+        parallel=True,
+        weights=None,
     ):
-        if blacklist is None:
-            blacklist = set()
-
-        (
-            vector_rows,
-            vector_metadata,
-            vector_state,
-            keyword_rows,
-            keyword_metadata,
-            keyword_state,
-        ) = self._search_components(
-            query_embedding,
-            query_text,
+        return super().search(
+            [query_embedding, query_text],
             predicates,
             target_results,
-            blacklist,
+            blacklist=blacklist,
             parallel=parallel,
-        )
-
-        combined_rows = self._combine_rows(
-            vector_rows,
-            keyword_rows,
-            target_results,
-        )
-        combined_metadata = self._merge_metadata(vector_metadata, keyword_metadata)
-        combined_state = HybridSearchState(
-            strategy="combined",
-            current_k=max(vector_state.current_k, keyword_state.current_k),
-            estimated_selectivity=max(
-                vector_state.estimated_selectivity,
-                keyword_state.estimated_selectivity,
-            ),
-            prefilter_cost=(vector_state.prefilter_cost + keyword_state.prefilter_cost),
-            postfilter_cost=(
-                vector_state.postfilter_cost + keyword_state.postfilter_cost
-            ),
-        )
-        return combined_rows, combined_metadata, combined_state
-
-
-class HybridTextVisualKeywordIndex:
-    def __init__(
-        self,
-        text_vector_hybrid_index: HybridVectorMetadataIndex,
-        visual_vector_hybrid_index: HybridVectorMetadataIndex,
-        keyword_hybrid_index: HybridKeywordMetadataIndex,
-    ):
-        self.text_vector_hybrid_index = text_vector_hybrid_index
-        self.visual_vector_hybrid_index = visual_vector_hybrid_index
-        self.keyword_hybrid_index = keyword_hybrid_index
-
-    @staticmethod
-    def _rank_score(rank: int) -> float:
-        return 1.0 / (rank + 1)
-
-    @staticmethod
-    def _merge_metadata(
-        *metadatas: dict[str, list[dict]],
-    ) -> dict[str, list[dict]]:
-        merged: dict[str, list[dict]] = {}
-        for md in metadatas:
-            for digest, entries in md.items():
-                if digest in merged:
-                    merged[digest] = merged[digest] + entries
-                else:
-                    merged[digest] = list(entries)
-        return merged
-
-    def _combine_rows(
-        self,
-        text_rows: list[tuple[float, str, str]],
-        visual_rows: list[tuple[float, str, str]],
-        keyword_rows: list[tuple[float, str, str]],
-        target_results: int,
-        weights: dict | None = None,
-    ) -> list[tuple[float, str, str]]:
-        if weights is None:
-            weights = {"textual": 1.0, "visual": 1.0, "keyword": 1.0}
-
-        t_weight = float(weights.get("textual", weights.get("text", 0.0) or 0.0))
-        v_weight = float(weights.get("visual", 0.0))
-        k_weight = float(weights.get("keyword", 0.0))
-
-        combined: dict[str, dict] = {}
-
-        for rank, row in enumerate(text_rows):
-            distance, digest, page = row
-            combined[digest] = {
-                "row": row,
-                "text_rank": rank,
-                "visual_rank": None,
-                "keyword_rank": None,
-            }
-
-        for rank, row in enumerate(visual_rows):
-            distance, digest, page = row
-            entry = combined.get(digest)
-            if entry is None:
-                combined[digest] = {
-                    "row": row,
-                    "text_rank": None,
-                    "visual_rank": rank,
-                    "keyword_rank": None,
-                }
-            else:
-                entry["visual_rank"] = rank
-
-        for rank, row in enumerate(keyword_rows):
-            distance, digest, page = row
-            entry = combined.get(digest)
-            if entry is None:
-                combined[digest] = {
-                    "row": row,
-                    "text_rank": None,
-                    "visual_rank": None,
-                    "keyword_rank": rank,
-                }
-            else:
-                entry["keyword_rank"] = rank
-                # Prefer a row from higher-scoring component for tie-breaking
-                text_rank = entry.get("text_rank")
-                visual_rank = entry.get("visual_rank")
-                if entry.get("row") is None or (
-                    text_rank is None and visual_rank is None
-                ):
-                    entry["row"] = row
-
-        scored_rows: list[tuple[float, tuple[float, str, str]]] = []
-        for entry in combined.values():
-            score = 0.0
-            if entry.get("text_rank") is not None:
-                score += t_weight * self._rank_score(entry["text_rank"])
-            if entry.get("visual_rank") is not None:
-                score += v_weight * self._rank_score(entry["visual_rank"])
-            if entry.get("keyword_rank") is not None:
-                score += k_weight * self._rank_score(entry["keyword_rank"])
-            scored_rows.append((score, entry["row"]))
-
-        scored_rows.sort(key=lambda item: (-item[0], item[1][0], item[1][1]))
-        return [row for _, row in scored_rows[:target_results]]
-
-    def _search_components(
-        self,
-        query_embedding,
-        query_text,
-        predicates,
-        target_results,
-        blacklist,
-        parallel: bool = True,
-    ):
-        search_k_vector = min(
-            self.text_vector_hybrid_index._index_total_entries(),
-            max(target_results * 3, 20),
-        )
-        search_k_visual = min(
-            self.visual_vector_hybrid_index._index_total_entries(),
-            max(target_results * 3, 20),
-        )
-        search_k_keyword = min(
-            self.keyword_hybrid_index._index_total_entries(),
-            max(target_results * 3, 20),
-        )
-
-        if parallel:
-            with ThreadPoolExecutor(max_workers=3) as executor:
-                text_future = executor.submit(
-                    self.text_vector_hybrid_index.search,
-                    query_embedding,
-                    predicates,
-                    search_k_vector,
-                    blacklist,
-                )
-                visual_future = executor.submit(
-                    self.visual_vector_hybrid_index.search,
-                    query_embedding,
-                    predicates,
-                    search_k_visual,
-                    blacklist,
-                )
-                keyword_future = executor.submit(
-                    self.keyword_hybrid_index.search,
-                    query_text,
-                    predicates,
-                    search_k_keyword,
-                )
-                text_rows, text_metadata, text_state = text_future.result()
-                visual_rows, visual_metadata, visual_state = visual_future.result()
-                keyword_rows, keyword_metadata, keyword_state = keyword_future.result()
-        else:
-            text_rows, text_metadata, text_state = self.text_vector_hybrid_index.search(
-                query_embedding, predicates, search_k_vector, blacklist
-            )
-            visual_rows, visual_metadata, visual_state = (
-                self.visual_vector_hybrid_index.search(
-                    query_embedding, predicates, search_k_visual, blacklist
-                )
-            )
-            keyword_rows, keyword_metadata, keyword_state = (
-                self.keyword_hybrid_index.search(
-                    query_text, predicates, search_k_keyword
-                )
-            )
-
-        return (
-            text_rows,
-            text_metadata,
-            text_state,
-            visual_rows,
-            visual_metadata,
-            visual_state,
-            keyword_rows,
-            keyword_metadata,
-            keyword_state,
-        )
-
-    def search(
-        self,
-        query_embedding,
-        query_text,
-        predicates,
-        target_results,
-        blacklist=None,
-        parallel: bool = True,
-        weights: dict | None = None,
-    ):
-        if blacklist is None:
-            blacklist = set()
-
-        (
-            text_rows,
-            text_metadata,
-            text_state,
-            visual_rows,
-            visual_metadata,
-            visual_state,
-            keyword_rows,
-            keyword_metadata,
-            keyword_state,
-        ) = self._search_components(
-            query_embedding,
-            query_text,
-            predicates,
-            target_results,
-            blacklist,
-            parallel=parallel,
-        )
-
-        combined_rows = self._combine_rows(
-            text_rows,
-            visual_rows,
-            keyword_rows,
-            target_results,
             weights=weights,
         )
-        combined_metadata = self._merge_metadata(
-            text_metadata,
-            visual_metadata,
-            keyword_metadata,
+
+
+class HybridTextVisualKeywordIndex(HybridIndex):
+    """Compatibility wrapper for the former three-component hybrid."""
+
+    def __init__(self, text_index, visual_index, keyword_index):
+        super().__init__([text_index, visual_index, keyword_index])
+
+    def search(
+        self,
+        text_query,
+        query_text=None,
+        predicates=None,
+        target_results=None,
+        blacklist=None,
+        parallel=True,
+        weights=None,
+    ):
+        return super().search(
+            [text_query, text_query, query_text],
+            predicates,
+            target_results,
+            blacklist=blacklist,
+            parallel=parallel,
+            weights=weights,
         )
-        combined_state = HybridSearchState(
-            strategy="combined",
-            current_k=max(
-                text_state.current_k,
-                visual_state.current_k,
-                keyword_state.current_k,
-            ),
-            estimated_selectivity=max(
-                text_state.estimated_selectivity,
-                visual_state.estimated_selectivity,
-                keyword_state.estimated_selectivity,
-            ),
-            prefilter_cost=(
-                text_state.prefilter_cost
-                + visual_state.prefilter_cost
-                + keyword_state.prefilter_cost
-            ),
-            postfilter_cost=(
-                text_state.postfilter_cost
-                + visual_state.postfilter_cost
-                + keyword_state.postfilter_cost
-            ),
-        )
-        return combined_rows, combined_metadata, combined_state

--- a/govscape/indexing/keyword.py
+++ b/govscape/indexing/keyword.py
@@ -256,15 +256,27 @@ class SQLiteKeywordIndex(AbstractKeywordIndex):
         self.conn = None
         self.cursor = None
         self.index = None
+        self._thread_local = threading.local()
         self._total_entries = -1
         self.VALID_CHARS = (
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 _"
         )
 
+    def _get_connection(self):
+        thread_state = self._thread_local
+        conn = getattr(thread_state, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self.db_path, check_same_thread=False)
+            thread_state.conn = conn
+        return conn
+
+    def _get_cursor(self):
+        return self._get_connection().cursor()
+
     def build_index(self):
         if not os.path.exists(self.index_keyword_directory):
             os.makedirs(self.index_keyword_directory)
-        self.conn = sqlite3.connect(self.db_path)
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self.cursor = self.conn.cursor()
         self.cursor.execute(
             """
@@ -279,39 +291,41 @@ class SQLiteKeywordIndex(AbstractKeywordIndex):
         self.conn.commit()
 
     def _has_name_column(self):
-        if self.conn is None:
-            self.load_index()
-        rows = self.cursor.execute("PRAGMA table_info(fts_txt)").fetchall()
+        cursor = self._get_cursor()
+        rows = cursor.execute("PRAGMA table_info(fts_txt)").fetchall()
         return any(str(row[1]) == "name" for row in rows)
 
     def add_batch(self, texts, digests, pages):
-        if self.conn is None:
-            self.load_index()
-        self.cursor.execute("BEGIN TRANSACTION;")
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute("BEGIN TRANSACTION;")
         has_name_column = self._has_name_column()
         for text, digest, page in zip(texts, digests, pages, strict=False):
             if has_name_column:
-                self.cursor.execute(
+                cursor.execute(
                     "INSERT INTO fts_txt (text, pdf_name, page_count, name) "
                     "VALUES (?, ?, ?, ?)",
                     [text, digest, page, digest],
                 )
             else:
-                self.cursor.execute(
+                cursor.execute(
                     "INSERT INTO fts_txt (text, pdf_name, page_count) VALUES (?, ?, ?)",
                     [text, digest, page],
                 )
-        self.conn.commit()
+        conn.commit()
 
     def load_index(self):
         os.makedirs(self.index_keyword_directory, exist_ok=True)
         if not os.path.exists(self.db_path):
             self.build_index()
-        self.conn = sqlite3.connect(self.db_path)
-        self.cursor = self.conn.cursor()
+        conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._thread_local.conn = conn
+        self.conn = conn
+        self.cursor = conn.cursor()
         if self._total_entries == -1:
-            self.cursor.execute("SELECT MAX(ROWID) FROM fts_txt")
-            row = self.cursor.fetchone()
+            cursor = conn.cursor()
+            cursor.execute("SELECT MAX(ROWID) FROM fts_txt")
+            row = cursor.fetchone()
             self._total_entries = row[0] if row and row[0] is not None else 0
 
     def save_index(self):
@@ -346,8 +360,7 @@ class SQLiteKeywordIndex(AbstractKeywordIndex):
 
     def _search_impl(self, query, k, allowed_names=None):
         query = self._clean_query(query)
-        if not self.cursor:
-            self.load_index()
+        cursor = self._get_cursor()
 
         params = [query]
         name_column = "name" if self._has_name_column() else "pdf_name"
@@ -369,17 +382,18 @@ class SQLiteKeywordIndex(AbstractKeywordIndex):
         params.append(k)
 
         try:
-            rows = self.cursor.execute(search_query, params).fetchall()
+            rows = cursor.execute(search_query, params).fetchall()
         except sqlite3.ProgrammingError:
             self.load_index()
-            rows = self.cursor.execute(search_query, params).fetchall()
+            cursor = self._get_cursor()
+            rows = cursor.execute(search_query, params).fetchall()
         distances = []
         digests = []
         pages = []
         for row in rows:
             digests.append(row[1])
             pages.append(str(row[2]))
-            distances.append(row[3])
+            distances.append(row[-1])
         return distances, digests, pages
 
     def search(self, query, k):

--- a/govscape/indexing/keyword.py
+++ b/govscape/indexing/keyword.py
@@ -11,6 +11,8 @@ from whoosh.index import create_in
 from whoosh.qparser import QueryParser
 from whoosh.query import And, Or, Term
 
+from .base import AbstractIndex
+
 lucene = None
 LuceneTerm = None
 _LUCENE_LOADED = False
@@ -96,7 +98,7 @@ def _load_lucene():
             raise ImportError("Lucene is not available in this environment") from e
 
 
-class AbstractKeywordIndex(ABC):
+class AbstractKeywordIndex(AbstractIndex, ABC):
     @abstractmethod
     def __init__(self, index_keyword_directory):
         self.index_keyword_directory = index_keyword_directory

--- a/govscape/indexing/metadata.py
+++ b/govscape/indexing/metadata.py
@@ -11,9 +11,10 @@ import duckdb
 import pyarrow as pa
 
 from ..query import EqualityPredicate, Predicate, RangePredicate
+from .base import AbstractIndex
 
 
-class AbstractMetadataIndex(ABC):
+class AbstractMetadataIndex(AbstractIndex, ABC):
     @abstractmethod
     def __init__(self, index_metadata_directory):
         self.index_metadata_directory = index_metadata_directory

--- a/govscape/indexing/vector.py
+++ b/govscape/indexing/vector.py
@@ -8,6 +8,8 @@ import numpy as np
 
 import pyarrow as pa
 
+from .base import AbstractIndex
+
 
 # Avoid annoying output from faiss during import
 @contextlib.contextmanager
@@ -28,11 +30,7 @@ with suppress_output():
     import faiss
 
 
-class AbstractVectorIndex(ABC):
-    @abstractmethod
-    def __init__(self):
-        pass
-
+class AbstractVectorIndex(AbstractIndex, ABC):
     @abstractmethod
     def build_index(self):
         pass

--- a/govscape/processing/ocr/README.md
+++ b/govscape/processing/ocr/README.md
@@ -79,7 +79,7 @@ OCRProcessingStage(
     data_model=data_model,
     ocr_type="easyocr",
     languages=["en", "fr"],  # Support multiple languages
-    gpu=True                  # Use GPU if available
+    gpu=True,  # Use GPU if available
 )
 ```
 
@@ -88,8 +88,8 @@ OCRProcessingStage(
 OCRProcessingStage(
     data_model=data_model,
     ocr_type="paddleocr",
-    language="en",           # Single language
-    use_gpu=True             # Use GPU if available
+    language="en",  # Single language
+    use_gpu=True,  # Use GPU if available
 )
 ```
 
@@ -98,7 +98,7 @@ OCRProcessingStage(
 OCRProcessingStage(
     data_model=data_model,
     ocr_type="olmocr",
-    model_name="default"     # Model variant
+    model_name="default",  # Model variant
 )
 ```
 
@@ -107,8 +107,8 @@ OCRProcessingStage(
 OCRProcessingStage(
     data_model=data_model,
     ocr_type="ocrmypdf",
-    language="eng",          # Tesseract language code
-    output_type="txt"        # Output format
+    language="eng",  # Tesseract language code
+    output_type="txt",  # Output format
 )
 ```
 
@@ -144,6 +144,7 @@ Example:
 ```python
 # ocr/tesseract_impl.py
 from .base_ocr import BaseOCR
+
 
 class TesseractImpl(BaseOCR):
     def __init__(self, language: str = "eng"):

--- a/govscape/query.py
+++ b/govscape/query.py
@@ -42,11 +42,15 @@ class Query:
         search_type: str,
         predicates: list[Predicate] | None = None,
         page: int = 1,
+        weights: dict | None = None,
     ):
         self.q_text = q_text
         self.search_type = search_type
         self.predicates = predicates if predicates is not None else []
         self.page = page
+        # Optional per-query weights for hybrid searches.
+        # Example: {"textual": 0.3, "visual": 0.3, "keyword": 0.4}
+        self.weights = weights or {}
 
 
 class Response:

--- a/govscape/server.py
+++ b/govscape/server.py
@@ -13,9 +13,8 @@ from .api import init_api
 from .config import ServerConfig
 from .indexing import (
     FAISSIndex,
+    HybridIndex,
     HybridKeywordMetadataIndex,
-    HybridKeywordVectorMetadataIndex,
-    HybridTextVisualKeywordIndex,
     HybridVectorMetadataIndex,
     LanceDBKeywordIndex,
     LuceneKeywordIndex,
@@ -99,14 +98,21 @@ class Server:
             self.keyword_index,
             self.metadata_index,
         )
-        self.keyword_vector_hybrid_index = HybridKeywordVectorMetadataIndex(
-            self.text_hybrid_index,
-            self.keyword_hybrid_index,
+        self.text_keyword_hybrid_index = HybridIndex(
+            [self.text_hybrid_index, self.keyword_hybrid_index]
         )
-        self.text_visual_keyword_hybrid_index = HybridTextVisualKeywordIndex(
-            self.text_hybrid_index,
-            self.visual_hybrid_index,
-            self.keyword_hybrid_index,
+        self.visual_keyword_hybrid_index = HybridIndex(
+            [self.visual_hybrid_index, self.keyword_hybrid_index]
+        )
+        self.text_visual_hybrid_index = HybridIndex(
+            [self.text_hybrid_index, self.visual_hybrid_index]
+        )
+        self.text_visual_keyword_hybrid_index = HybridIndex(
+            [
+                self.text_hybrid_index,
+                self.visual_hybrid_index,
+                self.keyword_hybrid_index,
+            ]
         )
 
         self.blacklist: set[str] = self._load_blacklist()
@@ -220,11 +226,9 @@ class Server:
             search_results = self._build_search_results(rows, pdf_metadata)
         elif search_type == "hybrid":
             query_embedding = self.text_model.encode_text(query.q_text, is_query=True)
-            query_text = query.q_text
             start = time.time()
-            rows, pdf_metadata, state = self.keyword_vector_hybrid_index.search(
-                query_embedding,
-                query_text,
+            rows, pdf_metadata, state = self.text_keyword_hybrid_index.search(
+                [query_embedding, query.q_text],
                 predicates,
                 results_needed_for_page,
                 blacklist=self.blacklist,
@@ -237,9 +241,32 @@ class Server:
                 f"results found after filtering: {len(rows)}"
             )
             search_results = self._build_search_results(rows, pdf_metadata)
+        elif search_type == "hybrid_visual_keyword":
+            query_embedding = self.visual_model.encode_text(query.q_text)
+            start = time.time()
+            rows, pdf_metadata, state = self.visual_keyword_hybrid_index.search(
+                [query_embedding, query.q_text],
+                predicates,
+                results_needed_for_page,
+                blacklist=self.blacklist,
+            )
+            print(f"Index Search took {time.time() - start} seconds")
+            search_results = self._build_search_results(rows, pdf_metadata)
+        elif search_type == "hybrid_text_visual":
+            text_embedding = self.text_model.encode_text(query.q_text, is_query=True)
+            visual_embedding = self.visual_model.encode_text(query.q_text)
+            start = time.time()
+            rows, pdf_metadata, state = self.text_visual_hybrid_index.search(
+                [text_embedding, visual_embedding],
+                predicates,
+                results_needed_for_page,
+                blacklist=self.blacklist,
+            )
+            print(f"Index Search took {time.time() - start} seconds")
+            search_results = self._build_search_results(rows, pdf_metadata)
         elif search_type == "hybrid_weights":
-            query_embedding = self.text_model.encode_text(query.q_text, is_query=True)
-            query_text = query.q_text
+            text_embedding = self.text_model.encode_text(query.q_text, is_query=True)
+            visual_embedding = self.visual_model.encode_text(query.q_text)
             weights = getattr(query, "weights", None) or {}
             # Normalize weights if provided
             try:
@@ -259,8 +286,7 @@ class Server:
 
             start = time.time()
             rows, pdf_metadata, state = self.text_visual_keyword_hybrid_index.search(
-                query_embedding,
-                query_text,
+                [text_embedding, visual_embedding, query.q_text],
                 predicates,
                 results_needed_for_page,
                 blacklist=self.blacklist,

--- a/govscape/server.py
+++ b/govscape/server.py
@@ -14,6 +14,7 @@ from .config import ServerConfig
 from .indexing import (
     FAISSIndex,
     HybridKeywordMetadataIndex,
+    HybridKeywordVectorMetadataIndex,
     HybridVectorMetadataIndex,
     LanceDBKeywordIndex,
     LuceneKeywordIndex,
@@ -96,6 +97,10 @@ class Server:
         self.keyword_hybrid_index = HybridKeywordMetadataIndex(
             self.keyword_index,
             self.metadata_index,
+        )
+        self.keyword_vector_hybrid_index = HybridKeywordVectorMetadataIndex(
+            self.text_hybrid_index,
+            self.keyword_hybrid_index,
         )
 
         self.blacklist: set[str] = self._load_blacklist()
@@ -199,6 +204,25 @@ class Server:
                 predicates,
                 results_needed_for_page,
                 blacklist=self.blacklist,
+            )
+            print(f"Index Search took {time.time() - start} seconds")
+            print(
+                "Search type: "
+                f"{search_type}, strategy: {state.strategy}, "
+                f"results found after filtering: {len(rows)}"
+            )
+            search_results = self._build_search_results(rows, pdf_metadata)
+        elif search_type == "hybrid":
+            query_embedding = self.text_model.encode_text(query.q_text, is_query=True)
+            query_text = query.q_text
+            start = time.time()
+            rows, pdf_metadata, state = self.keyword_vector_hybrid_index.search(
+                query_embedding,
+                query_text,
+                predicates,
+                results_needed_for_page,
+                blacklist=self.blacklist,
+                parallel=True,
             )
             print(f"Index Search took {time.time() - start} seconds")
             print(

--- a/govscape/server.py
+++ b/govscape/server.py
@@ -15,6 +15,7 @@ from .indexing import (
     FAISSIndex,
     HybridKeywordMetadataIndex,
     HybridKeywordVectorMetadataIndex,
+    HybridTextVisualKeywordIndex,
     HybridVectorMetadataIndex,
     LanceDBKeywordIndex,
     LuceneKeywordIndex,
@@ -100,6 +101,11 @@ class Server:
         )
         self.keyword_vector_hybrid_index = HybridKeywordVectorMetadataIndex(
             self.text_hybrid_index,
+            self.keyword_hybrid_index,
+        )
+        self.text_visual_keyword_hybrid_index = HybridTextVisualKeywordIndex(
+            self.text_hybrid_index,
+            self.visual_hybrid_index,
             self.keyword_hybrid_index,
         )
 
@@ -223,6 +229,43 @@ class Server:
                 results_needed_for_page,
                 blacklist=self.blacklist,
                 parallel=True,
+            )
+            print(f"Index Search took {time.time() - start} seconds")
+            print(
+                "Search type: "
+                f"{search_type}, strategy: {state.strategy}, "
+                f"results found after filtering: {len(rows)}"
+            )
+            search_results = self._build_search_results(rows, pdf_metadata)
+        elif search_type == "hybrid_weights":
+            query_embedding = self.text_model.encode_text(query.q_text, is_query=True)
+            query_text = query.q_text
+            weights = getattr(query, "weights", None) or {}
+            # Normalize weights if provided
+            try:
+                total = sum(
+                    float(weights.get(k, 0.0)) for k in ["textual", "visual", "keyword"]
+                )
+            except Exception:
+                total = 0.0
+
+            if total and total > 0:
+                normalized = {
+                    k: float(weights.get(k, 0.0)) / total
+                    for k in ["textual", "visual", "keyword"]
+                }
+            else:
+                normalized = None
+
+            start = time.time()
+            rows, pdf_metadata, state = self.text_visual_keyword_hybrid_index.search(
+                query_embedding,
+                query_text,
+                predicates,
+                results_needed_for_page,
+                blacklist=self.blacklist,
+                parallel=True,
+                weights=normalized,
             )
             print(f"Index Search took {time.time() - start} seconds")
             print(

--- a/interface/src/lib/components/HybridSliders.svelte
+++ b/interface/src/lib/components/HybridSliders.svelte
@@ -1,0 +1,74 @@
+<script>
+  import { searchStore, searchActions } from '$lib/stores/search';
+  import { get } from 'svelte/store';
+
+  let weights = get(searchStore).hybridWeights || { textual: 0.33, visual: 0.33, keyword: 0.34 };
+
+  // Keep local weights in sync with store changes
+  $: if (get(searchStore).hybridWeights && get(searchStore).hybridWeights !== weights) {
+    weights = get(searchStore).hybridWeights;
+  }
+
+  function updateWeight(key, value) {
+    const numeric = Number(value);
+    weights = { ...weights, [key]: numeric };
+    // Update store
+    searchActions.setHybridWeights({ [key]: numeric });
+  }
+</script>
+
+<div class="hybrid-sliders">
+  <div class="slider-row">
+    <label for="textual">Textual</label>
+    <input id="textual" type="range" min="0" max="1" step="0.01" bind:value={weights.textual} on:input={(e) => updateWeight('textual', e.target.value)} />
+    <div class="value">{Math.round(weights.textual * 100)}%</div>
+  </div>
+  <div class="slider-row">
+    <label for="visual">Visual</label>
+    <input id="visual" type="range" min="0" max="1" step="0.01" bind:value={weights.visual} on:input={(e) => updateWeight('visual', e.target.value)} />
+    <div class="value">{Math.round(weights.visual * 100)}%</div>
+  </div>
+  <div class="slider-row">
+    <label for="keyword">Keyword</label>
+    <input id="keyword" type="range" min="0" max="1" step="0.01" bind:value={weights.keyword} on:input={(e) => updateWeight('keyword', e.target.value)} />
+    <div class="value">{Math.round(weights.keyword * 100)}%</div>
+  </div>
+  <div class="note">Weights are sent as-is and normalized server-side.</div>
+</div>
+
+<style>
+  .hybrid-sliders {
+    margin-top: 12px;
+    width: 100%;
+    max-width: 600px;
+    background: #fff;
+    padding: 12px;
+    border-radius: 12px;
+    box-shadow: 0 1px 6px rgba(32,33,36,0.06);
+  }
+  .slider-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
+  }
+  .slider-row label {
+    width: 90px;
+    font-size: 0.85rem;
+    color: var(--text-color-secondary);
+  }
+  .slider-row input[type=range] {
+    flex: 1 1 0;
+  }
+  .slider-row .value {
+    width: 48px;
+    text-align: right;
+    font-size: 0.85rem;
+    color: var(--text-color-primary);
+  }
+  .note {
+    margin-top: 6px;
+    font-size: 0.8rem;
+    color: var(--text-color-secondary);
+  }
+</style>

--- a/interface/src/lib/components/SearchBox.svelte
+++ b/interface/src/lib/components/SearchBox.svelte
@@ -5,6 +5,7 @@
   import { goto } from '$app/navigation';
   import { createEventDispatcher } from 'svelte';
   import AdvancedSearch from './AdvancedSearch.svelte';
+  import HybridSliders from './HybridSliders.svelte';
   import GlobeIcon from './icons/GlobeIcon.svelte';
   import FilterIcon from './icons/FilterIcon.svelte';
 
@@ -19,6 +20,7 @@
     { id: 'textual', label: 'Semantic Text Search', placeholder: 'Search PDFs with context-rich text search...' },
     { id: 'visual', label: 'Visual Search', placeholder: 'Search PDFs using image semantics...' },
     { id: 'keyword', label: 'Keyword Search', placeholder: 'Enter keywords for search...' },
+    { id: 'hybrid_weights', label: 'Hybrid (Text+Visual+Keyword)', placeholder: 'Hybrid search combining text, visual, and keyword...'},
   ];
 
   let currentSearchMode = searchModes[0];
@@ -109,8 +111,9 @@
     <div
       class="search-mode-toggle-bg"
       class:toggle-left={currentSearchMode.id === 'textual'}
-      class:toggle-middle={currentSearchMode.id === 'visual'}
-      class:toggle-right={currentSearchMode.id === 'keyword'}
+        class:toggle-middle={currentSearchMode.id === 'visual'}
+        class:toggle-right={currentSearchMode.id === 'keyword'}
+        class:toggle-fourth={currentSearchMode.id === 'hybrid_weights'}
     ></div>
     {#each searchModes as mode}
       <button
@@ -176,6 +179,9 @@
   </div>
 
   <AdvancedSearch show={$searchStore.showFilters} />
+  {#if $searchStore.currentSearchMode === 'hybrid_weights'}
+    <HybridSliders />
+  {/if}
 </div>
 
 <style>
@@ -277,7 +283,7 @@
     position: absolute;
     top: 4px;
     left: 4px;
-    width: calc(33.33% - 4px);
+    width: calc(25% - 4px);
     height: calc(100% - 8px);
     background: var(--color-primary);
     border-radius: 999px;
@@ -293,7 +299,11 @@
   }
 
   .search-mode-toggle-bg.toggle-right {
-    transform: translateX(203.5%);
+    transform: translateX(200%);
+  }
+
+  .search-mode-toggle-bg.toggle-fourth {
+    transform: translateX(300%);
   }
 
   .search-mode-tabs button {

--- a/interface/src/lib/stores/search.js
+++ b/interface/src/lib/stores/search.js
@@ -15,6 +15,7 @@ export const searchStore = writable({
   hasMore: false,
   totalCount: null,
   totalPages: null,
+  hybridWeights: { textual: 0.33, visual: 0.33, keyword: 0.34 },
 });
 
 export const searchActions = {
@@ -36,6 +37,16 @@ export const searchActions = {
       hasMore: false,
       totalCount: null,
       totalPages: null,
+    }));
+  },
+
+  setHybridWeights: (weights) => {
+    searchStore.update(store => ({
+      ...store,
+      hybridWeights: {
+        ...store.hybridWeights,
+        ...weights
+      }
     }));
   },
 
@@ -93,10 +104,15 @@ export const searchActions = {
 
     try {
       const { query, filters, currentSearchMode } = get(searchStore)
+      const body = { query, filters, searchType: currentSearchMode, page: pageNumber };
+      if (currentSearchMode === 'hybrid_weights') {
+        body.weights = get(searchStore).hybridWeights;
+      }
+
       const responseData = await apiFetch('/search/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query, filters, searchType: currentSearchMode, page: pageNumber })
+        body: JSON.stringify(body)
       });
 
       const imageBase = getImageBaseUrl();

--- a/interface/src/routes/search/+page.svelte
+++ b/interface/src/routes/search/+page.svelte
@@ -36,7 +36,7 @@
 
     return {
       q,
-      mode: ['textual', 'visual', 'keyword'].includes(mode) ? mode : 'textual',
+      mode: ['textual', 'visual', 'keyword', 'hybrid_weights'].includes(mode) ? mode : 'textual',
       page: Number.isFinite(pageParam) && pageParam > 0 ? pageParam : 1,
       filters: {
         crawledAfter: crawledAfter || null,

--- a/scripts/mock_api.py
+++ b/scripts/mock_api.py
@@ -1,0 +1,26 @@
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+
+
+@app.route("/api/search/", methods=["POST"])
+def search():
+    data = request.get_json() or {}
+    # Echo back weights and provide empty results so frontend can exercise UI
+    return jsonify(
+        {
+            "results": [],
+            "pagination": {
+                "page": data.get("page", 1),
+                "page_size": 20,
+                "has_next_page": False,
+                "total_count": 0,
+                "total_pages": 0,
+            },
+            "received": data,
+        }
+    )
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8080)

--- a/tests/test_hybrid_index.py
+++ b/tests/test_hybrid_index.py
@@ -1,10 +1,73 @@
 import numpy as np
 
 from govscape.indexing.hybrid import (
+    HybridIndex,
     HybridKeywordMetadataIndex,
+    HybridSearchState,
     HybridVectorMetadataIndex,
 )
 from govscape.query import EqualityPredicate
+
+
+class DummyHybridIndex:
+    def __init__(self, rows):
+        self.rows = rows
+        self.queries = []
+
+    def search(self, query, _predicates, _k, blacklist):
+        self.queries.append((query, blacklist))
+        rows = [row for row in self.rows if row[1] not in blacklist]
+        state = HybridSearchState("test", len(rows), 1.0, 0.0, 0.0)
+        metadata = {row[1]: [] for row in rows}
+        return rows, metadata, state
+
+    def total_entries(self):
+        return len(self.rows)
+
+
+def test_generic_hybrid_combines_two_indices_with_weights():
+    text_index = DummyHybridIndex([(0.1, "text_only", "1"), (0.2, "shared", "1")])
+    keyword_index = DummyHybridIndex([(0.1, "shared", "1"), (0.2, "keyword_only", "1")])
+    hybrid = HybridIndex([text_index, keyword_index], weights=[0.2, 0.8])
+
+    rows, metadata, _state = hybrid.search(
+        ["text query", "keyword query"],
+        predicates=[],
+        target_results=3,
+        blacklist={"text_only"},
+        parallel=False,
+    )
+
+    assert [digest for _, digest, _ in rows] == [
+        "shared",
+        "keyword_only",
+    ]
+    assert text_index.queries == [("text query", {"text_only"})]
+    assert keyword_index.queries == [("keyword query", {"text_only"})]
+    assert set(metadata) == {"shared", "keyword_only"}
+
+
+def test_generic_hybrid_supports_three_indices():
+    indices = [
+        DummyHybridIndex([(0.1, "text", "1")]),
+        DummyHybridIndex([(0.1, "visual", "1")]),
+        DummyHybridIndex([(0.1, "keyword", "1")]),
+    ]
+    hybrid = HybridIndex(indices, weights=[1.0, 1.0, 1.0])
+
+    rows, _metadata, _state = hybrid.search(
+        ["text", "visual", "keyword"],
+        predicates=[],
+        target_results=3,
+        parallel=False,
+    )
+
+    assert {digest for _, digest, _ in rows} == {"text", "visual", "keyword"}
+    assert [index.queries[0][0] for index in indices] == [
+        "text",
+        "visual",
+        "keyword",
+    ]
 
 
 class DummyVectorIndex:

--- a/tests/test_keyword_indexes.py
+++ b/tests/test_keyword_indexes.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 
 from govscape.indexing import (
@@ -92,4 +94,24 @@ def test_keyword_indexes_round_trip(tmp_path, index_cls, sample_documents):
     _, filtered_pdfs, _ = reloaded_index.search_filtered(
         "resilience", k=5, allowed_names=allowed
     )
+    assert filtered_pdfs == [digests[1]]
+
+
+def test_sqlite_keyword_index_search_filtered_is_thread_safe(
+    tmp_path, sample_documents
+):
+    texts, digests, pages = sample_documents
+    index_dir = tmp_path / "keyword_index"
+    index = SQLiteKeywordIndex(index_dir.as_posix())
+    index.build_index()
+    index.add_batch(texts, digests, pages)
+    index.save_index()
+
+    index.load_index()
+    allowed = {digests[1]}
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(index.search_filtered, "resilience", 5, allowed)
+        _, filtered_pdfs, _ = future.result()
+
     assert filtered_pdfs == [digests[1]]

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -184,6 +184,16 @@ def test_server_keyword_search_uses_keyword_index(server_fixture):
     ]
 
 
+def test_server_hybrid_search_combines_keyword_and_vector(server_fixture):
+    server = server_fixture
+    response = server.search(Query("site:gov", search_type="hybrid"))
+
+    assert len(response.results) == server.config.k
+    returned = [result["pdf"] for result in response.results]
+    assert "doc_0.pdf" in returned
+    assert "keyword_doc_0.pdf" in returned
+
+
 def test_blacklist_missing_file_is_empty(server_fixture):
     server = server_fixture
     assert server.blacklist == set()


### PR DESCRIPTION
This PR builds an abstract hybrid search when previously there was hybrid keyword/vector search and hybrid keyword/textual/visual search existing separately. There are updated vector, keyword, metadata, and metadata-aware hybrid indexes to inherit from the AbstractIndex class. There is a generic HybridIndex that accepts a list of indexes, accepts matching weights, runs component searches in parallel, combines results using weighted reciprocal rank scoring, merges metadata and propagates blacklist/filter behavior. Now we can have text/keyword, visual/keyword, text/visual, and text/visual/keyword search.